### PR TITLE
Add ApplicationErrorExtension JUnit Jupiter testing extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,13 @@
 
         <!-- provided dependencies -->
 
+        <!-- This is needed to support having the test utilities as part of the library JAR -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+        </dependency>
+
         <!-- optional dependencies -->
 
         <dependency>

--- a/src/main/java/org/kiwiproject/dropwizard/error/test/junit/jupiter/ApplicationErrorExtension.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/test/junit/jupiter/ApplicationErrorExtension.java
@@ -1,0 +1,135 @@
+package org.kiwiproject.dropwizard.error.test.junit.jupiter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.kiwiproject.dropwizard.error.model.ApplicationError;
+import org.kiwiproject.dropwizard.error.model.PersistentHostInformation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * A JUnit Jupiter extension that ensures the {@link PersistentHostInformation} is set on {@link ApplicationError}
+ * before all tests, and cleared after all tests have completed.
+ * <p>
+ * If you need access to the underlying {@link PersistentHostInformation}, you can retrieve it via the {@link HostInfo}
+ * annotation. You can get it using a {@link BeforeAll} annotated method:
+ * <pre>
+ * private static PersistentHostInformation myStaticHostInfo;
+ *
+ * {@literal @}BeforeAll
+ *  static void setUpBeforeAll(@HostInfo PersistentHostInformation hostInfo) {
+ *      myStaticHostInfo = hostInfo;
+ *  }
+ *
+ * {@literal @}Test
+ *  void test() {
+ *      assertThat(myStaticHostInfo.getHostname()).isEqualTo("your-hostname");
+ *      // ...
+ *  }
+ * </pre>
+ * <p>
+ * or via a {@link BeforeEach} annotated method:
+ * <pre>
+ * private PersistentHostInformation myHostInfo;
+ *
+ * {@literal @}BeforeEach
+ *  void setUp(@HostInfo PersistentHostInformation hostInfo) {
+ *      myHostInfo = hostInfo;
+ *  }
+ *
+ * {@literal @}Test
+ *  void test() {
+ *      assertThat(myHostInfo.getHostname()).isEqualTo("your-hostname");
+ *      //
+ *  }
+ * </pre>
+ * <p>
+ * or even on an individual test method:
+ * <pre>
+ * {@literal @}Test
+ *  void test(@HostInfo PersistentHostInformation hostInfo) {
+ *      assertThat(hostInfo.getHostname()).isEqualTo("your-hostname");
+ *      //
+ *  }
+ * </pre>
+ * <p>
+ * <b>NOTE</b>: It is recommended that you do not mix and match these within a single unit test. It should
+ * still work, but we would not be surprised if you get weird "Heisenbugs" popping up.
+ */
+@Slf4j
+public class ApplicationErrorExtension implements BeforeAllCallback, AfterAllCallback, ParameterResolver {
+
+    /**
+     * Add this annotation to a {@link PersistentHostInformation} parameter in a method annotated with
+     * {@link BeforeAll}, {@link BeforeEach}, or {@link Test} methods in order to get the persistent
+     * host information.
+     */
+    @Target(ElementType.PARAMETER)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    public @interface HostInfo {
+    }
+
+    private static final ExtensionContext.Namespace NAMESPACE =
+            ExtensionContext.Namespace.create(ApplicationErrorExtension.class);
+
+    private static final String HOST_INFO_KEY = "PersistentHostInformation";
+    private static final int DEFAULT_PORT = 8080;
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        LOG.trace("Setting persistent host information for ApplicationError");
+
+        InetAddress localHost = getLocalHost();
+        ApplicationError.setPersistentHostInformation(localHost.getHostName(), localHost.getHostAddress(), DEFAULT_PORT);
+
+        context.getStore(NAMESPACE).put(HOST_INFO_KEY, ApplicationError.getPersistentHostInformation());
+    }
+
+    private InetAddress getLocalHost() {
+        try {
+            return InetAddress.getLocalHost();
+        } catch (UnknownHostException e) {
+            LOG.debug("Error getting local host. Will default to loopback address", e);
+            return InetAddress.getLoopbackAddress();
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        LOG.trace("Clearing persistent host information from ApplicationError");
+        ApplicationError.clearPersistentHostInformation();
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        LOG.trace("Checking if we support this type: {}", parameterContext.getParameter().getType());
+
+        return parameterContext.isAnnotated(HostInfo.class) &&
+                parameterContext.getParameter().getType() == PersistentHostInformation.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        var hostInformation = extensionContext.getStore(ApplicationErrorExtension.NAMESPACE)
+                .get(ApplicationErrorExtension.HOST_INFO_KEY, PersistentHostInformation.class);
+
+        LOG.trace("Resolving parameter based on the ApplicationErrorExtension context: host={}, address={}, port= {}",
+                hostInformation.getHostName(), hostInformation.getIpAddress(), hostInformation.getPort());
+
+        return hostInformation;
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/error/test/junit/jupiter/ApplicationErrorExtensionIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/test/junit/jupiter/ApplicationErrorExtensionIntegrationTest.java
@@ -1,0 +1,32 @@
+package org.kiwiproject.dropwizard.error.test.junit.jupiter;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwiproject.dropwizard.error.model.PersistentHostInformation;
+import org.kiwiproject.dropwizard.error.test.junit.jupiter.ApplicationErrorExtension.HostInfo;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * This test uses the {@link ApplicationErrorExtension} as it is meant to be used in tests.
+ */
+@DisplayName("ApplicationErrorExtension: Integration")
+@ExtendWith(ApplicationErrorExtension.class)
+@ExtendWith(SoftAssertionsExtension.class)
+class ApplicationErrorExtensionIntegrationTest {
+
+    @Test
+    void shouldSetPersistentHostInformation(@HostInfo PersistentHostInformation hostInfo,
+                                            SoftAssertions softly) throws UnknownHostException {
+
+        InetAddress localhost = InetAddress.getLocalHost();
+
+        softly.assertThat(hostInfo.getHostName()).isEqualTo(localhost.getHostName());
+        softly.assertThat(hostInfo.getIpAddress()).isEqualTo(localhost.getHostAddress());
+        softly.assertThat(hostInfo.getPort()).isEqualTo(8080);
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/error/test/junit/jupiter/ApplicationErrorExtensionUnitTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/test/junit/jupiter/ApplicationErrorExtensionUnitTest.java
@@ -1,0 +1,181 @@
+package org.kiwiproject.dropwizard.error.test.junit.jupiter;
+
+import static java.util.Objects.isNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.base.Verify;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.kiwiproject.dropwizard.error.model.ApplicationError;
+import org.kiwiproject.dropwizard.error.model.PersistentHostInformation;
+import org.kiwiproject.dropwizard.error.test.junit.jupiter.ApplicationErrorExtension.HostInfo;
+
+import java.lang.reflect.Parameter;
+
+/**
+ * This test is a unit test of {@link ApplicationErrorExtension}, exercising each callback method individually.
+ */
+@DisplayName("ApplicationErrorExtension: Unit")
+@ExtendWith(SoftAssertionsExtension.class)
+class ApplicationErrorExtensionUnitTest {
+
+    private ApplicationErrorExtension extension;
+    private ExtensionContext extensionContext;
+    private ExtensionContext.Store store;
+
+    @BeforeEach
+    void setUp() {
+        ApplicationError.clearPersistentHostInformation();
+        Verify.verify(isNull(ApplicationError.getPersistentHostInformation()),
+                "Tests cannot proceed b/c PersistentHostInformation exists!");
+
+        extension = new ApplicationErrorExtension();
+        extensionContext = mock(ExtensionContext.class);
+        store = mock(ExtensionContext.Store.class);
+        when(extensionContext.getStore(any(ExtensionContext.Namespace.class))).thenReturn(store);
+    }
+
+    @Test
+    void shouldSetPersistentHostInformation_InBeforeAll(SoftAssertions softly) {
+        extension.beforeAll(extensionContext);
+
+        var hostInfo = ApplicationError.getPersistentHostInformation();
+        assertThat(hostInfo).isNotNull();
+
+        softly.assertThat(hostInfo.getHostName()).isNotBlank();
+        softly.assertThat(hostInfo.getIpAddress()).isNotBlank();
+        softly.assertThat(hostInfo.getPort()).isGreaterThan(0);
+
+        verifyGetStore();
+        verify(store).put("PersistentHostInformation", hostInfo);
+        verifyNoMoreInteractions(extensionContext, store);
+    }
+
+    @Test
+    void shouldClearPersistentHostInformation_InAfterAll(SoftAssertions softly) {
+        ApplicationError.setPersistentHostInformation("host42", "192.168.1.42", 9042);
+
+        extension.afterAll(extensionContext);
+
+        softly.assertThat(ApplicationError.getPersistentHostInformation()).isNull();
+
+        verifyNoInteractions(extensionContext, store);
+    }
+
+    @Nested
+    class SupportsParameter {
+
+        private ParameterContext parameterContext;
+
+        @BeforeEach
+        void setUp() {
+            parameterContext = mock(ParameterContext.class);
+        }
+
+        @Test
+        void shouldBeFalse_WhenNotHostInfoAnnotation() {
+            when(parameterContext.isAnnotated(any())).thenReturn(false);
+
+            var parameter = getParameter("sampleMethodWithSoftAssertionsParameter", SoftAssertions.class);
+            when(parameterContext.getParameter()).thenReturn(parameter);
+
+            var supports = extension.supportsParameter(parameterContext, null);
+
+            assertThat(supports).isFalse();
+
+            verifyNoInteractions(extensionContext);
+            verify(parameterContext).isAnnotated(HostInfo.class);
+        }
+
+        @Test
+        void shouldBeFalse_WhenHostInfoAnnotation_OnIncorrectParameterType() {
+            when(parameterContext.isAnnotated(any())).thenReturn(true);
+
+            var parameter = getParameter("sampleMethodWithHostInfo", PersistentHostInformation.class);
+            when(parameterContext.getParameter()).thenReturn(parameter);
+
+            var supports = extension.supportsParameter(parameterContext, null);
+
+            assertThat(supports).isTrue();
+
+            verifyNoInteractions(extensionContext);
+            verify(parameterContext).isAnnotated(HostInfo.class);
+        }
+
+        @Test
+        void shouldBeTrue_WhenHostInfoAnnotation_OnPersistentHostInformationParameter() {
+            when(parameterContext.isAnnotated(any())).thenReturn(true);
+
+            var parameter = getParameter("sampleMethodWithIncorrectHostInfoParameterType", String.class);
+            when(parameterContext.getParameter()).thenReturn(parameter);
+
+            var supports = extension.supportsParameter(parameterContext, null);
+
+            assertThat(supports).isFalse();
+
+            verifyNoInteractions(extensionContext);
+            verify(parameterContext).isAnnotated(HostInfo.class);
+        }
+    }
+
+    private Parameter getParameter(String methodName, Class<?> parameterTypes) {
+        try {
+            var method = getClass().getDeclaredMethod(methodName, parameterTypes);
+            return method.getParameters()[0];
+        } catch (NoSuchMethodException e) {
+            throw new IllegalArgumentException("Method not found: " + methodName);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    void sampleMethodWithSoftAssertionsParameter(SoftAssertions softly) {
+        // no-op
+    }
+
+    @SuppressWarnings("unused")
+    void sampleMethodWithHostInfo(@HostInfo PersistentHostInformation hostInfo) {
+        // nop-op
+    }
+
+    @SuppressWarnings("unused")
+    void sampleMethodWithIncorrectHostInfoParameterType(@HostInfo String hostInfo) {
+        // no-op
+    }
+
+    @Test
+    void shouldResolveHostInfoParameter() {
+        ApplicationError.setPersistentHostInformation("host42", "192.168.1.42", 9042);
+        var hostInfo = ApplicationError.getPersistentHostInformation();
+        when(store.get(anyString(), any())).thenReturn(hostInfo);
+
+        var resolved = extension.resolveParameter(null, extensionContext);
+
+        assertThat(resolved).isSameAs(hostInfo);
+
+        verifyGetStore();
+        verify(store).get("PersistentHostInformation", PersistentHostInformation.class);
+        verifyNoMoreInteractions(extensionContext, store);
+    }
+
+    private void verifyGetStore() {
+        verify(extensionContext).getStore(argThat(namespaceArg -> {
+            assertThat(namespaceArg).isEqualTo(ExtensionContext.Namespace.create(ApplicationErrorExtension.class));
+            return true;
+        }));
+    }
+}

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+    <logger name="org.kiwiproject" level="TRACE"/>
+    <logger name="liquibase" level="INFO"/>
+    <root level="WARN">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
* Add ApplicationErrorExtension
* Add unit and integration tests for ApplicationErrorExtension
* Add junit-jupiter-api as provided dependency in pom so that
  the extension can use the JUnit APIs
* Add Logback config file for testing

Fixes #16