### PR TITLE
Add ApplicationErrorVerifications

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorDao.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorDao.java
@@ -131,6 +131,9 @@ public interface ApplicationErrorDao {
      *
      * @param error the ApplicationError to insert or update
      * @return the ID of the new or existing application error
+     * @implNote Do not assume that {@code error} is updated when this method is called. Changes to the object are
+     * implementation-dependent. If you need an updated version, pass the returned long into {@link #getById(long)}.
+     * @see #insertError(ApplicationError)
      * @see #incrementCount(long)
      */
     long insertOrIncrementCount(ApplicationError error);

--- a/src/main/java/org/kiwiproject/dropwizard/error/test/mockito/ApplicationErrorVerifications.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/test/mockito/ApplicationErrorVerifications.java
@@ -1,0 +1,71 @@
+package org.kiwiproject.dropwizard.error.test.mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kiwiproject.collect.KiwiLists.first;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import lombok.experimental.UtilityClass;
+import org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao;
+import org.kiwiproject.dropwizard.error.model.ApplicationError;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+/**
+ * Utilities for performing Mockito verifications on calls on mock {@link ApplicationErrorDao} instances.
+ */
+@UtilityClass
+public class ApplicationErrorVerifications {
+
+    /**
+     * {@link org.mockito.Mockito#verify(Object) Verify} that
+     * {@link ApplicationErrorDao#insertOrIncrementCount(ApplicationError)} was called <em>exactly one</em> time on
+     * {@code errorDao} <em>and that no other interactions occurred</em>.
+     * <p>
+     * Returns the ApplicationError that was verified, which can be used to perform further inspection and/or
+     * assertions.
+     *
+     * @param errorDao a Mockito mock of {@link ApplicationErrorDao}
+     * @return the {@link ApplicationError} argument assuming the verification passes
+     * @throws org.mockito.exceptions.base.MockitoAssertionError if verification fails. The exact type will be a
+     *                                                           subclass describing on the problem.
+     */
+    public static ApplicationError verifyExactlyOneInsertOrIncrementCount(ApplicationErrorDao errorDao) {
+        var argumentCaptor = ArgumentCaptor.forClass(ApplicationError.class);
+        verify(errorDao).insertOrIncrementCount(argumentCaptor.capture());
+        verifyNoMoreInteractions(errorDao);
+
+        // If we're here, there should be only ONE value given the above verifications,
+        // but be conservative and make the assertion anyway.
+        var allValues = argumentCaptor.getAllValues();
+        assertThat(allValues)
+                .describedAs("Expected exactly one ApplicationError but found %d", allValues.size())
+                .hasSize(1);
+
+        return first(allValues);
+    }
+
+    /**
+     * {@link org.mockito.Mockito#verify(Object) Verify} that
+     * {@link ApplicationErrorDao#insertOrIncrementCount(ApplicationError)} was called <em>at least</em> one time on
+     * {@code errorDao} and <em>that no other interactions occurred</em>.
+     * <p>
+     * Returns the list of ApplicationErrors that were verified, which can be used to perform further inspection and/or
+     * assertions. The order of the returned ApplicationError list is the order in which {@code insertOrIncrementCount}
+     * was called.
+     *
+     * @param errorDao a Mockito mock of {@link ApplicationErrorDao}
+     * @return all {@link ApplicationError} arguments assuming the verification passes
+     * @throws org.mockito.exceptions.base.MockitoAssertionError if verification fails. The exact type will be a
+     *                                                           subclass describing on the problem.
+     */
+    public static List<ApplicationError> verifyAtLeastOneInsertOrIncrementCount(ApplicationErrorDao errorDao) {
+        var argumentCaptor = ArgumentCaptor.forClass(ApplicationError.class);
+        verify(errorDao, atLeastOnce()).insertOrIncrementCount(argumentCaptor.capture());
+        verifyNoMoreInteractions(errorDao);
+
+        return argumentCaptor.getAllValues();
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/error/test/mockito/ApplicationErrorVerificationsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/test/mockito/ApplicationErrorVerificationsTest.java
@@ -1,0 +1,193 @@
+package org.kiwiproject.dropwizard.error.test.mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.kiwiproject.collect.KiwiLists.first;
+import static org.kiwiproject.collect.KiwiLists.second;
+import static org.mockito.Mockito.mock;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao;
+import org.kiwiproject.dropwizard.error.model.ApplicationError;
+import org.kiwiproject.dropwizard.error.test.junit.jupiter.ApplicationErrorExtension;
+import org.mockito.exceptions.verification.NoInteractionsWanted;
+import org.mockito.exceptions.verification.TooManyActualInvocations;
+import org.mockito.exceptions.verification.WantedButNotInvoked;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.stream.IntStream;
+
+@DisplayName("ApplicationErrorVerifications")
+@ExtendWith(ApplicationErrorExtension.class)
+@Slf4j
+class ApplicationErrorVerificationsTest {
+
+    /**
+     * Sample class that records application errors when given specific input.
+     */
+    @AllArgsConstructor
+    private static class BusinessLogicService {
+
+        private final ApplicationErrorDao errorDao;
+
+        void performSomeProcessingThatCanFail(String input) {
+            switch (input) {
+                case "foo": // one error with exception
+                    var fooError = ApplicationError.newUnresolvedError("Processing failed for input: foo");
+                    errorDao.insertOrIncrementCount(fooError);
+                    break;
+
+                case "bar": // one error with exception
+                    var cause = new IOException("I/O error");
+                    var ex = new UncheckedIOException(cause);
+                    var barError = ApplicationError.newUnresolvedError("Processing threw error with cause for input: bar", ex);
+                    errorDao.insertOrIncrementCount(barError);
+                    break;
+
+                case "baz": // one error plus a second call on errorDao
+                    var bazError = ApplicationError.newUnresolvedError("Processing failed for input: baz");
+                    errorDao.insertOrIncrementCount(bazError);
+                    errorDao.countAllErrors();
+                    break;
+            }
+
+            LOG.info("Processing complete for input: {}", input);
+        }
+    }
+
+    private ApplicationErrorDao errorService;
+    private BusinessLogicService businessService;
+
+    @BeforeEach
+    void setUp() {
+        errorService = mock(ApplicationErrorDao.class);
+        businessService = new BusinessLogicService(errorService);
+    }
+
+    @Nested
+    class VerifyExactlyOneInsertOrIncrementCount {
+
+        @Nested
+        class WhenVerificationSucceeds {
+
+            @Test
+            void shouldReturnApplicationError() {
+                businessService.performSomeProcessingThatCanFail("foo");
+                var appError = ApplicationErrorVerifications.verifyExactlyOneInsertOrIncrementCount(errorService);
+
+                assertThat(appError.getDescription()).isEqualTo("Processing failed for input: foo");
+                assertThat(appError.getExceptionType()).isNull();
+                assertThat(appError.getExceptionCauseType()).isNull();
+            }
+
+            @Test
+            void shouldReturnApplicationError_HavingCause() {
+                businessService.performSomeProcessingThatCanFail("bar");
+                var appError = ApplicationErrorVerifications.verifyExactlyOneInsertOrIncrementCount(errorService);
+
+                assertThat(appError.getDescription()).isEqualTo("Processing threw error with cause for input: bar");
+                assertThat(appError.getExceptionType()).isEqualTo(UncheckedIOException.class.getName());
+                assertThat(appError.getExceptionCauseType()).isEqualTo(IOException.class.getName());
+            }
+        }
+
+        @Nested
+        class WhenVerificationFails {
+
+            @Test
+            void shouldFailWhenNoApplicationErrors() {
+                businessService.performSomeProcessingThatCanFail("this won't fail");
+
+                assertThatThrownBy(() ->
+                        ApplicationErrorVerifications.verifyExactlyOneInsertOrIncrementCount(errorService))
+                        .isExactlyInstanceOf(WantedButNotInvoked.class);
+            }
+
+            @Test
+            void shouldFailWhenUnwantedInteractions() {
+                businessService.performSomeProcessingThatCanFail("baz");
+
+                assertThatThrownBy(() ->
+                        ApplicationErrorVerifications.verifyExactlyOneInsertOrIncrementCount(errorService))
+                        .isExactlyInstanceOf(NoInteractionsWanted.class);
+            }
+
+            @Test
+            void shouldFailWhenMoreThanOneApplicationErrorCreated() {
+                businessService.performSomeProcessingThatCanFail("foo");
+                businessService.performSomeProcessingThatCanFail("foo");
+
+                assertThatThrownBy(() ->
+                        ApplicationErrorVerifications.verifyExactlyOneInsertOrIncrementCount(errorService))
+                        .isExactlyInstanceOf(TooManyActualInvocations.class);
+            }
+        }
+    }
+
+    @Nested
+    class VerifyAtLeastOneInsertOrIncrementCount {
+
+        @Nested
+        class WhenVerificationSucceeds {
+
+            @Test
+            void shouldReturnApplicationErrors() {
+                businessService.performSomeProcessingThatCanFail("foo");
+                businessService.performSomeProcessingThatCanFail("bar");
+                var appErrors = ApplicationErrorVerifications.verifyAtLeastOneInsertOrIncrementCount(errorService);
+
+                var firstAppError = first(appErrors);
+                assertThat(firstAppError.getDescription()).isEqualTo("Processing failed for input: foo");
+                assertThat(firstAppError.getExceptionType()).isNull();
+                assertThat(firstAppError.getExceptionCauseType()).isNull();
+
+                var secondAppError = second(appErrors);
+                assertThat(secondAppError.getDescription()).isEqualTo("Processing threw error with cause for input: bar");
+                assertThat(secondAppError.getExceptionType()).isEqualTo(UncheckedIOException.class.getName());
+                assertThat(secondAppError.getExceptionCauseType()).isEqualTo(IOException.class.getName());
+            }
+
+            @Test
+            void shouldReturnManyApplicationErrors() {
+                var numErrors = 20;
+                IntStream.rangeClosed(1, numErrors).forEach(ignored -> businessService.performSomeProcessingThatCanFail("foo"));
+
+                var appErrors = ApplicationErrorVerifications.verifyAtLeastOneInsertOrIncrementCount(errorService);
+                assertThat(appErrors).hasSize(numErrors);
+            }
+        }
+
+        @Nested
+        class WhenVerificationFails {
+
+            @Test
+            void shouldFailWhenNoApplicationErrors() {
+                businessService.performSomeProcessingThatCanFail("this won't fail");
+                businessService.performSomeProcessingThatCanFail("this also won't fail");
+                businessService.performSomeProcessingThatCanFail("good here too");
+
+                assertThatThrownBy(() ->
+                        ApplicationErrorVerifications.verifyAtLeastOneInsertOrIncrementCount(errorService))
+                        .isExactlyInstanceOf(WantedButNotInvoked.class);
+            }
+
+            @Test
+            void shouldFailWhenUnwantedInteractions() {
+                businessService.performSomeProcessingThatCanFail("foo");
+                businessService.performSomeProcessingThatCanFail("baz");
+
+                assertThatThrownBy(() ->
+                        ApplicationErrorVerifications.verifyAtLeastOneInsertOrIncrementCount(errorService))
+                        .isExactlyInstanceOf(NoInteractionsWanted.class);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
* Add ApplicationErrorVerifications test utility
* Update docs on ApplicationErrorDao#insertOrIncrementCount to clarify
  the expected behavior, specifically that no assumption should be made
  whether the ApplicationError argument is mutated.

Fixes #27