### PR TITLE
Don't bootstrap logging when using ResourceExtension

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/error/resource/ApplicationErrorResourceTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/resource/ApplicationErrorResourceTest.java
@@ -42,6 +42,7 @@ class ApplicationErrorResourceTest {
     private static final ApplicationErrorResource ERROR_RESOURCE = new ApplicationErrorResource(ERROR_DAO);
 
     private static final ResourceExtension RESOURCES = ResourceExtension.builder()
+            .bootstrapLogging(false)
             .addResource(ERROR_RESOURCE)
             .build();
 

--- a/src/test/java/org/kiwiproject/dropwizard/error/resource/GotErrorsResourceTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/resource/GotErrorsResourceTest.java
@@ -19,6 +19,7 @@ class GotErrorsResourceTest {
     private static final DataStoreType DATA_STORE_TYPE = DataStoreType.NOT_SHARED;
 
     private static final ResourceExtension RESOURCES = ResourceExtension.builder()
+            .bootstrapLogging(false)
             .addResource(new GotErrorsResource(DATA_STORE_TYPE))
             .build();
 


### PR DESCRIPTION
The reason is that, when ResourceExtension bootstraps logging, the
log level is set to WARN and then we never see logging at lower levels
once the resource test has completed. By telling ResourceExtension not
to bootstrap logging, it won't change our test logging configuration.
This should really be the default behavior IMHO...