### PR TITLE
Enhance logging in ApplicationErrorVerificationsTest

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/error/test/mockito/ApplicationErrorVerificationsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/test/mockito/ApplicationErrorVerificationsTest.java
@@ -42,6 +42,7 @@ class ApplicationErrorVerificationsTest {
                 case "foo": // one error with exception
                     var fooError = ApplicationError.newUnresolvedError("Processing failed for input: foo");
                     errorDao.insertOrIncrementCount(fooError);
+                    logProcessingComplete(Level.WARN, input);
                     break;
 
                 case "bar": // one error with exception
@@ -49,16 +50,30 @@ class ApplicationErrorVerificationsTest {
                     var ex = new UncheckedIOException(cause);
                     var barError = ApplicationError.newUnresolvedError("Processing threw error with cause for input: bar", ex);
                     errorDao.insertOrIncrementCount(barError);
+                    logProcessingComplete(Level.WARN, input);
                     break;
 
                 case "baz": // one error plus a second call on errorDao
                     var bazError = ApplicationError.newUnresolvedError("Processing failed for input: baz");
                     errorDao.insertOrIncrementCount(bazError);
                     errorDao.countAllErrors();
+                    logProcessingComplete(Level.WARN, input);
+                    break;
+
+                default:
+                    logProcessingComplete(Level.INFO, input);
                     break;
             }
+        }
 
-            LOG.info("Processing complete for input: {}", input);
+        private enum Level {INFO, WARN}
+
+        static void logProcessingComplete(Level level, String input) {
+            if (level == Level.WARN) {
+                LOG.warn("Processing completed with errors for input: {}", input);
+            } else if (level == Level.INFO) {
+                LOG.info("Processing completed successfully for input: {}", input);
+            }
         }
     }
 


### PR DESCRIPTION
Enhance logging in the BusinessLogicService test class to log at
WARN level if we threw an ApplicationError, and INFO level if there
was no ApplicationError.

@implNote:
Because SLF4J doesn't have have a generic log method that accepts an
SLF4J Level - even in the new 2.0.0 API, see long thread here:
https://jira.qos.ch/browse/SLF4J-124 - I resorted to defining my own
small crappy enum and method to do this.