### PR TITLE
Add ErrorContextBuilder

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/ErrorContext.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/ErrorContext.java
@@ -8,16 +8,17 @@ import java.util.Optional;
 
 /**
  * This library provides an easy way to store application errors in your service's local (e.g. Postgres) database.
+ * This interface defines the general contract, and instances are built using {@link ErrorContextBuilder}.
  * <p>
  * This acts much like a Dropwizard bundle in that it creates an {@link ApplicationErrorDao} for use anywhere in
  * your application, and registers an
  * {@link org.kiwiproject.dropwizard.error.resource.ApplicationErrorResource ApplicationErrorResource} which
  * exposes application errors via REST. The {@link #errorDao()} method provides the DAO once an {@link ErrorContext}
- * has been built by one of the build methods in [TODO - add link to ErrorContextBuilder].
+ * has been built by one of the build methods in {@link ErrorContextBuilder}.
  * <p>
  * It also registers a health check that reports healthy if no errors have occurred in a configurable time window. The
  * default value is the last 15 minutes. If desired, you can disable the creation of the health check by calling
- * [TODO - add link to ErrorContextBuilder#skipHealthCheck()] when constructing the instance.
+ * {@link ErrorContextBuilder#skipHealthCheck()} when constructing the instance.
  * <p>
  * We currently support storing errors to a relational database with JDBI 3. If your application does not currently
  * have a database or uses something else, then we also provide an option to use an in-memory H2 database.
@@ -26,15 +27,14 @@ import java.util.Optional;
  * To start creating application errors you will first need to create the database
  * table (unless you are using the in-memory H2 database). See {@code dropwizard-app-errors-migrations.xml} in the
  * source code for more details; this is a Liquibase migration file. Once the table exists, build an instance
- * using [TODO - add link to ErrorContextBuilder]. You can then supply the {@link ApplicationErrorDao} to anywhere
+ * using {@link ErrorContextBuilder}. You can then supply the {@link ApplicationErrorDao} to anywhere
  * in your application, e.g. other services or DAOs, resources, etc. Once your application has started, clients can
  * retrieve and resolve application errors via the REST endpoint.
- * <p>
- * TODO - add @see to ErrorContextBuilder
  *
  * @implNote The reason this is <em>not</em> a Dropwizard bundle is mainly because it would not have the necessary
  * components (such as a Dropwizard {@code DataSourceFactory} or JDBI 3 {@code Jdbi} instance) during the
  * Dropwizard bundle initialization lifecycle.
+ * @see ErrorContextBuilder
  */
 public interface ErrorContext {
 
@@ -55,7 +55,7 @@ public interface ErrorContext {
     /**
      * Return the {@link RecentErrorsHealthCheck}, mainly so that the time window information can be obtained if it
      * is needed for some reason, e.g. logging it at application startup. Note if
-     * [TODO-add link to builder#skipHealthCheck] was called this will return an empty {@link Optional}.
+     * {@link ErrorContextBuilder#skipHealthCheck()} was called this will return an empty {@link Optional}.
      *
      * @return an Optional containing the {@link RecentErrorsHealthCheck}, or an empty Optional
      */

--- a/src/main/java/org/kiwiproject/dropwizard/error/ErrorContextBuilder.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/ErrorContextBuilder.java
@@ -1,0 +1,289 @@
+package org.kiwiproject.dropwizard.error;
+
+import static java.util.Objects.nonNull;
+import static org.kiwiproject.dropwizard.error.ErrorContextUtilities.checkCommonArguments;
+import static org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc.createInMemoryH2Database;
+import static org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc.isH2DataStore;
+
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.setup.Environment;
+import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.Jdbi;
+import org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc;
+import org.kiwiproject.dropwizard.error.health.TimeWindow;
+import org.kiwiproject.dropwizard.error.model.DataStoreType;
+import org.kiwiproject.dropwizard.jdbi3.Jdbi3Builders;
+
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+
+/**
+ * Builder for {@link ErrorContext} implementations.
+ * <p>
+ * To start building, you call {@link #newInstance()}. After that, there must be at the minimum three methods used:
+ * <ol>
+ * <li>{@link #environment(Environment)}</li>
+ * <li>{@link #serviceDetails(ServiceDetails)}</li>
+ * <li>And one of:
+ * <ul>
+ * <li>{@link #buildInMemoryH2()}</li>
+ * <li>{@link #buildWithDataStoreFactory(DataSourceFactory)}</li>
+ * <li>{@link #buildWithJdbi3(Jdbi)}</li>
+ * </ul>
+ * </ol>
+ * <p>
+ * Example for an in-memory H2 version of {@link ErrorContext}.
+ * <pre>
+ * var serviceDetails = ServiceDetails.from(theHostname, theIpAddress, thePortNumber);
+ * var errorContext = ErrorContextBuilder.newInstance()
+ *     .environment(theDropwizardEnvironment)
+ *     .serviceDetails(serviceDetails)
+ *     .buildInMemoryH2();
+ * </pre>
+ * <p>
+ * Example for a JDBI 3 version of {@link ErrorContext} (using Kiwi's {@link Jdbi3Builders} to build the
+ * {@link Jdbi} instance).
+ * <pre>
+ * var jdbi = Jdbi3Builders.buildManagedJdbi3(
+ *     theDropwizardEnvironment,
+ *     theDataSourceFactory,
+ *     theHealthCheckName);
+ *
+ * var serviceDetails = ServiceDetails.from(theHostname,theIpAddress, thePortNumber);
+ * var errorContext = ErrorContextBuilder.newInstance()
+ *     .environment(theDropwizardEnvironment)
+ *     .serviceDetails (serviceDetails)
+ *     .buildWithJdbi3(jdbi);
+ * </pre>
+ * <p>
+ * All of the terminal build methods use {@link DataStoreType} to determine if the {@link ErrorContext} instance is
+ * {@link DataStoreType#SHARED shared} (i.e. multiple instances of the same service read and write to the same database)
+ * or {@link DataStoreType#NOT_SHARED not shared} (i.e. each service instance has its own segregated database). You can
+ * change the defaults (listed below) by explicitly calling the {@link #dataStoreType(DataStoreType)} method with the
+ * store type you want.
+ * Defaults:
+ * <ul>
+ * <li>{@link #buildInMemoryH2()} -> {@link DataStoreType#NOT_SHARED} (<b>NOTE:</b> this cannot be overridden)</li>
+ * <li>{@link #buildWithDataStoreFactory(DataSourceFactory)}
+ * <ul>
+ * <li>If the database defined by the {@link DataSourceFactory} is an H2 instance -> {@link DataStoreType#NOT_SHARED}</li>
+ * <li>Otherwise, {@link DataStoreType#SHARED}</li>
+ * </ul>
+ * </li>
+ * <li>{@link #buildWithJdbi3(Jdbi)} -> {@link DataStoreType#SHARED}</li>
+ */
+@Slf4j
+public class ErrorContextBuilder {
+
+    private static final String DEFAULT_DATABASE_HEALTH_CHECK_NAME = "applicationErrorsDatabase";
+
+    private Environment environment;
+    private ServiceDetails serviceDetails;
+    private DataStoreType dataStoreType;
+    private boolean dataStoreTypeAlreadySet;
+    private boolean addHealthCheck = true;
+    private long timeWindowValue = TimeWindow.DEFAULT_TIME_WINDOW_MINUTES;
+    private TemporalUnit timeWindowUnit = ChronoUnit.MINUTES;
+    private boolean healthCheckTimeWindowAlreadySet;
+
+    public static ErrorContextBuilder newInstance() {
+        return new ErrorContextBuilder();
+    }
+
+    /**
+     * Sets the Dropwizard {@link Environment} to use with this builder.
+     *
+     * @param environment the {@link Environment}
+     * @return this builder
+     */
+    public ErrorContextBuilder environment(Environment environment) {
+        this.environment = environment;
+        return this;
+    }
+
+    /**
+     * Sets the {@link ServiceDetails} to use with this builder.
+     *
+     * @param serviceDetails the {@link ServiceDetails}
+     * @return this builder
+     */
+    public ErrorContextBuilder serviceDetails(ServiceDetails serviceDetails) {
+        this.serviceDetails = serviceDetails;
+        return this;
+    }
+
+    /**
+     * Explicitly configures the {@link DataStoreType} to use with this builder.
+     *
+     * @param dataStoreType the {@link DataStoreType}
+     * @return this builder
+     * @implNote The builder implementations have default values; using this will override those defaults.
+     * @see #buildInMemoryH2()
+     * @see #buildWithDataStoreFactory(DataSourceFactory)
+     * @see #buildWithJdbi3(Jdbi)
+     */
+    public ErrorContextBuilder dataStoreType(DataStoreType dataStoreType) {
+        if (nonNull(dataStoreType)) {
+            this.dataStoreType = dataStoreType;
+            this.dataStoreTypeAlreadySet = true;
+        }
+
+        return this;
+    }
+
+    /**
+     * Configures the resulting {@link ErrorContext} so that it does not create/register a health check with Dropwizard.
+     *
+     * @return this builder
+     */
+    public ErrorContextBuilder skipHealthCheck() {
+        this.addHealthCheck = false;
+        return this;
+    }
+
+    /**
+     * Configures the {@link TimeWindow} for the health check. If an error occurs within this time window, the
+     * health check will report as unhealthy. If there are no errors inside of this window, the health check will
+     * report as healthy.
+     *
+     * @param timeWindow the {@link TimeWindow}
+     * @return this builder
+     * @implNote This will override any value set by {@link #timeWindowValue(long)} and
+     * {@link #timeWindowUnit(TemporalUnit)}. Also, it will recast the values given in terms of
+     * {@link ChronoUnit#MINUTES minutes}.
+     */
+    public ErrorContextBuilder timeWindow(TimeWindow timeWindow) {
+        if (nonNull(timeWindow)) {
+            this.timeWindowValue = timeWindow.getDuration().toMinutes();
+            this.timeWindowUnit = ChronoUnit.MINUTES;
+            this.healthCheckTimeWindowAlreadySet = true;
+        }
+
+        return this;
+    }
+
+    /**
+     * Configures the length of time for the health check. If an error occurs within this time window, the
+     * health check will report as unhealthy. If there are no errors inside of this window, the health check will
+     * report as healthy.
+     *
+     * @param timeWindowValue the length of time
+     * @return this builder
+     * @implNote This value will be overwritten/ignored if {@link #timeWindow(TimeWindow)} is invoked.
+     */
+    public ErrorContextBuilder timeWindowValue(long timeWindowValue) {
+        if (healthCheckTimeWindowAlreadySet) {
+            logTimeWindowAlreadySetWarning("timeWindowValue", timeWindowValue);
+        } else {
+            this.timeWindowValue = timeWindowValue;
+        }
+
+        return this;
+    }
+
+    /**
+     * Configures the {@link TemporalUnit} for the health check. If an error occurs within this time window, the
+     * health check will report as unhealthy. If there are no errors inside of this window, the health check will
+     * report as healthy.
+     *
+     * @param timeWindowUnit the {@link TemporalUnit}
+     * @return this builder
+     * @implNote This value will be overwritten/ignored if {@link #timeWindow(TimeWindow)} is invoked.
+     */
+    public ErrorContextBuilder timeWindowUnit(TemporalUnit timeWindowUnit) {
+        if (healthCheckTimeWindowAlreadySet) {
+            logTimeWindowAlreadySetWarning("timeWindowUnit", timeWindowUnit);
+        } else if (nonNull(timeWindowUnit)) {
+            this.timeWindowUnit = timeWindowUnit;
+        }
+
+        return this;
+    }
+
+    private static void logTimeWindowAlreadySetWarning(String fieldName, Object fieldValue) {
+        LOG.warn("Ignoring {}={} because a TimeWindow has been set already and takes priority." +
+                        " Call only (1) timeWindow(), or (2) timeWindowValue() and/or timeWindowUnit().",
+                fieldName, fieldValue);
+    }
+
+    /**
+     * Build an {@link ErrorContext} backed by an in-memory H2 database that uses JDBI version 3.
+     *
+     * @return a new {@link ErrorContext} instance
+     * @implNote Always sets dataStoreType to {@link DataStoreType#NOT_SHARED}, since this builds an
+     * in-memory database that can only be accessed from within the service in which it resides.
+     */
+    public ErrorContext buildInMemoryH2() {
+        if (dataStoreTypeAlreadySet && dataStoreType == DataStoreType.SHARED) {
+            forceH2DatabaseToBeNotSharedWithWarning();
+        } else {
+            dataStoreType = DataStoreType.NOT_SHARED;
+        }
+
+        checkCommonArguments(environment, serviceDetails, dataStoreType, timeWindowValue, timeWindowUnit);
+
+        var dataSourceFactory = createInMemoryH2Database();
+        var jdbi = Jdbi3Builders.buildManagedJdbi(environment, dataSourceFactory, DEFAULT_DATABASE_HEALTH_CHECK_NAME);
+
+        return newJdbi3ErrorContext(jdbi);
+    }
+
+    /**
+     * Build an {@link ErrorContext} using given the {@code dataSourceFactory} that uses JDBI version 3.
+     *
+     * @return a new {@link ErrorContext} instance
+     * @implNote If you do not invoke {@link #dataStoreType(DataStoreType)} prior to calling this method, this method
+     * will attempt to determine which {@link DataStoreType} it should use by calling
+     * {@link ApplicationErrorJdbc#dataStoreTypeOf(DataSourceFactory)}.
+     */
+    public ErrorContext buildWithDataStoreFactory(DataSourceFactory dataSourceFactory) {
+        if (dataStoreTypeAlreadySet && isH2DataStore(dataSourceFactory)) {
+            forceH2DatabaseToBeNotSharedWithWarning();
+        } else if (!dataStoreTypeAlreadySet) {
+            dataStoreType = ApplicationErrorJdbc.dataStoreTypeOf(dataSourceFactory);
+        }
+
+        checkCommonArguments(environment, serviceDetails, dataStoreType, timeWindowValue, timeWindowUnit);
+
+        LOG.info("Creating a {} JDBI (version 3) ErrorContext instance from the dataSourceFactory", dataStoreType);
+        var jdbi = Jdbi3Builders.buildManagedJdbi(environment, dataSourceFactory, DEFAULT_DATABASE_HEALTH_CHECK_NAME);
+
+        return newJdbi3ErrorContext(jdbi);
+    }
+
+    private void forceH2DatabaseToBeNotSharedWithWarning() {
+        LOG.warn("An in-memory H2 database was requested with a SHARED data store type." +
+                " This will be converted to a NOT_SHARED data store type.");
+        this.dataStoreType = DataStoreType.NOT_SHARED;
+    }
+
+    /**
+     * Build an {@link ErrorContext} that uses JDBI version 3.
+     *
+     * @return a new {@link ErrorContext} instance
+     * @implNote If you do not invoke {@link #dataStoreType(DataStoreType)} prior to calling this method, this method
+     * will default to using a value of {@link DataStoreType#SHARED}. Otherwise we would need to open a database
+     * connection, inspect the database metadata, etc. to figure out the database, and we don't want to do all this.
+     * If you are using an in-memory database, then be sure to configure the data store type before calling.
+     */
+    public ErrorContext buildWithJdbi3(Jdbi jdbi) {
+        if (!dataStoreTypeAlreadySet) {
+            dataStoreType = DataStoreType.SHARED;
+        }
+
+        checkCommonArguments(environment, serviceDetails, dataStoreType, timeWindowValue, timeWindowUnit);
+
+        return newJdbi3ErrorContext(jdbi);
+    }
+
+    private Jdbi3ErrorContext newJdbi3ErrorContext(Jdbi jdbi) {
+        return new Jdbi3ErrorContext(
+                environment,
+                serviceDetails,
+                jdbi,
+                dataStoreType,
+                addHealthCheck,
+                timeWindowValue,
+                timeWindowUnit);
+    }
+}

--- a/src/main/java/org/kiwiproject/dropwizard/error/ErrorContextUtilities.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/ErrorContextUtilities.java
@@ -25,11 +25,13 @@ class ErrorContextUtilities {
 
     static void checkCommonArguments(Environment environment,
                                      ServiceDetails serviceDetails,
+                                     DataStoreType dataStoreType,
                                      long timeWindowValue,
                                      TemporalUnit timeWindowUnit) {
 
         checkArgumentNotNull(environment, "Dropwizard Environment cannot be null");
-        checkArgumentNotNull(serviceDetails, "ServiceDetails cannot be null");
+        checkArgumentNotNull(serviceDetails, "serviceDetails cannot be null");
+        checkArgumentNotNull(dataStoreType, "dataStoreType cannot ne null");
         checkArgument(timeWindowValue > 0, "timeWindowValue must be positive");
         checkArgumentNotNull(timeWindowUnit, "timeWindowUnit cannot be null");
     }

--- a/src/main/java/org/kiwiproject/dropwizard/error/Jdbi3ErrorContext.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/Jdbi3ErrorContext.java
@@ -1,7 +1,6 @@
 package org.kiwiproject.dropwizard.error;
 
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
-import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.dropwizard.error.ErrorContextUtilities.checkCommonArguments;
 import static org.kiwiproject.dropwizard.error.ErrorContextUtilities.registerRecentErrorsHealthCheckOrNull;
@@ -48,11 +47,11 @@ class Jdbi3ErrorContext implements ErrorContext {
                       long timeWindowValue,
                       TemporalUnit timeWindowUnit) {
 
-        checkCommonArguments(environment, serviceDetails, timeWindowValue, timeWindowUnit);
+        checkCommonArguments(environment, serviceDetails, dataStoreType, timeWindowValue, timeWindowUnit);
         checkArgumentNotNull(jdbi, "Jdbi (version 3) instance cannot be null");
         setPersistentHostInformationFrom(serviceDetails);
 
-        this.dataStoreType = requireNotNull(dataStoreType, "dataStoreType cannot be null");
+        this.dataStoreType = dataStoreType;
         this.errorDao = getOnDemandErrorDao(jdbi);
         this.healthCheck = registerRecentErrorsHealthCheckOrNull(
                 addHealthCheck, environment, errorDao, serviceDetails, timeWindowValue, timeWindowUnit);

--- a/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbc.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbc.java
@@ -100,11 +100,12 @@ public class ApplicationErrorJdbc {
      *
      * @implNote Currently this uses ONLY the driver class to make this determination and always assumes H2 databases
      * are NOT shared. This simplistic implementation could change in the future.
+     * @see #isH2DataStore(DataSourceFactory)
      */
     public static DataStoreType dataStoreTypeOf(DataSourceFactory dataSourceFactory) {
         checkArgumentNotNull(dataSourceFactory);
 
-        if (dataSourceFactory.getDriverClass().equals(H2_DRIVER)) {
+        if (isH2DataStore(dataSourceFactory)) {
             return DataStoreType.NOT_SHARED;
         }
 
@@ -116,6 +117,8 @@ public class ApplicationErrorJdbc {
      *
      * @param dataSourceFactory the DataSourceFactory to check
      * @return true if the driver class is the H2 driver, false otherwise (including null argument)
+     * @implNote Currently this uses ONLY the driver class to make this determination and always assumes H2 databases
+     * are NOT shared. This simplistic implementation could change in the future.
      */
     public static boolean isH2DataStore(DataSourceFactory dataSourceFactory) {
         if (isNull(dataSourceFactory)) {

--- a/src/main/java/org/kiwiproject/dropwizard/error/model/ApplicationError.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/model/ApplicationError.java
@@ -103,7 +103,7 @@ public class ApplicationError {
      * and {@code port} when created via the static factory methods.
      * <p>
      * Please note this is intended to be called only <em>once</em> at initialization (see the "{@code build*}" methods
-     * in [TODO-add link to builder]). Alas Java does not permit a "set only once" semantic to non-final variables.
+     * in {@link org.kiwiproject.dropwizard.error.ErrorContextBuilder ErrorContextBuilder}. Alas Java does not permit a "set only once" semantic to non-final variables.
      * However, this does allow calling more than once for unit testing purposes.
      *
      * @param hostName  the persistent host name

--- a/src/test/java/org/kiwiproject/dropwizard/error/ErrorContextBuilderTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/ErrorContextBuilderTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -177,6 +178,10 @@ class ErrorContextBuilderTest {
 
         private void assertNoHealthCheck(SoftAssertions softly, ErrorContext errorContext) {
             softly.assertThat(errorContext.recentErrorsHealthCheck()).isEmpty();
+
+            var healthChecks = environment.healthChecks();
+            verify(healthChecks, never())
+                    .register(eq("recentErrorsHealthCheck"), isA(RecentErrorsHealthCheck.class));
         }
 
         @Nested

--- a/src/test/java/org/kiwiproject/dropwizard/error/ErrorContextBuilderTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/ErrorContextBuilderTest.java
@@ -1,0 +1,474 @@
+package org.kiwiproject.dropwizard.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.util.Duration;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc;
+import org.kiwiproject.dropwizard.error.dao.jdbi3.Jdbi3ApplicationErrorDao;
+import org.kiwiproject.dropwizard.error.health.RecentErrorsHealthCheck;
+import org.kiwiproject.dropwizard.error.health.TimeWindow;
+import org.kiwiproject.dropwizard.error.model.ApplicationError;
+import org.kiwiproject.dropwizard.error.model.DataStoreType;
+import org.kiwiproject.dropwizard.error.resource.ApplicationErrorResource;
+import org.kiwiproject.dropwizard.error.resource.GotErrorsResource;
+import org.kiwiproject.dropwizard.jdbi3.Jdbi3Builders;
+import org.kiwiproject.test.dropwizard.mockito.DropwizardMockitoMocks;
+import org.kiwiproject.test.junit.jupiter.PostgresLiquibaseTestExtension;
+import org.postgresql.Driver;
+
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+
+/**
+ * The majority of the tests here use an in-memory H2 database, but there are several tests that use
+ * Postgres via the {@link PostgresLiquibaseTestExtension}, which is registered at the class level.
+ */
+@DisplayName("ErrorContextBuilder")
+@ExtendWith(SoftAssertionsExtension.class)
+class ErrorContextBuilderTest {
+
+    @RegisterExtension
+    static final PostgresLiquibaseTestExtension POSTGRES =
+            new PostgresLiquibaseTestExtension("dropwizard-app-errors-migrations.xml");
+
+    private Environment environment;
+    private ServiceDetails serviceDetails;
+    private long timeWindowAmount;
+    private ChronoUnit timeWindowUnit;
+
+    @BeforeEach
+    void setUp() {
+        environment = DropwizardMockitoMocks.mockEnvironment();
+        serviceDetails = new ServiceDetails("localhost", "127.0.0.1", 8080);
+        timeWindowAmount = 20;
+        timeWindowUnit = ChronoUnit.MINUTES;
+    }
+
+    @AfterEach
+    void tearDown() {
+        ApplicationError.clearPersistentHostInformation();
+    }
+
+    @Nested
+    class ShouldThrowIllegalArgumentException {
+
+        @Test
+        void whenNoEnvironmentIsProvided(SoftAssertions softly) {
+            var builder = ErrorContextBuilder.newInstance()
+                    .serviceDetails(serviceDetails)
+                    .dataStoreType(DataStoreType.SHARED)
+                    .timeWindowValue(timeWindowAmount)
+                    .timeWindowUnit(timeWindowUnit);
+
+            assertIllegalArgumentExceptionThrownBuilding(
+                    softly, builder, "Dropwizard Environment cannot be null");
+        }
+
+        @Test
+        void whenNoServiceDetailsIsProvided(SoftAssertions softly) {
+            var builder = ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .dataStoreType(DataStoreType.NOT_SHARED)
+                    .timeWindowValue(timeWindowAmount)
+                    .timeWindowUnit(timeWindowUnit);
+
+            assertIllegalArgumentExceptionThrownBuilding(
+                    softly, builder, "serviceDetails cannot be null");
+        }
+
+        @ParameterizedTest
+        @ValueSource(longs = {-15, -1, 0})
+        void whenTimeWindowValueIsNotPositive(long amount, SoftAssertions softly) {
+            var builder = ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .dataStoreType(DataStoreType.SHARED)
+                    .timeWindowValue(amount)
+                    .timeWindowUnit(timeWindowUnit);
+
+            assertIllegalArgumentExceptionThrownBuilding(softly, builder, "timeWindowValue must be positive");
+        }
+
+        private void assertIllegalArgumentExceptionThrownBuilding(SoftAssertions softly,
+                                                                  ErrorContextBuilder builder,
+                                                                  String expectedMessage) {
+            softly.assertThatThrownBy(
+                    builder::buildInMemoryH2)
+                    .isExactlyInstanceOf(IllegalArgumentException.class)
+                    .hasMessage(expectedMessage);
+
+            softly.assertThatThrownBy(
+                    () -> builder.buildWithDataStoreFactory(mock(DataSourceFactory.class)))
+                    .isExactlyInstanceOf(IllegalArgumentException.class)
+                    .hasMessage(expectedMessage);
+
+            softly.assertThatThrownBy(
+                    () -> builder.buildWithJdbi3(mock(Jdbi.class)))
+                    .isExactlyInstanceOf(IllegalArgumentException.class)
+                    .hasMessage(expectedMessage);
+        }
+    }
+
+    @Nested
+    class RecentApplicationErrorsHealthCheck {
+
+        @Test
+        void shouldHaveRecentErrorsHealthCheckWithDefaultTimeWindow(SoftAssertions softly) {
+            var builder = ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .dataStoreType(DataStoreType.NOT_SHARED);
+
+            assertDefaultTimeWindow(softly, builder.buildInMemoryH2());
+
+            var dataSourceFactory = ApplicationErrorJdbc.createInMemoryH2Database();
+            assertDefaultTimeWindow(softly, builder.buildWithDataStoreFactory(dataSourceFactory));
+
+            var jdbi = Jdbi3Builders.buildManagedJdbi(environment, dataSourceFactory);
+            assertDefaultTimeWindow(softly, builder.buildWithJdbi3(jdbi));
+        }
+
+        @Test
+        void shouldIgnoreNullTimeWindowUnitArguments(SoftAssertions softly) {
+            var builder = ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .dataStoreType(DataStoreType.NOT_SHARED)
+                    .timeWindowUnit(null);
+
+            assertDefaultTimeWindow(softly, builder.buildInMemoryH2());
+        }
+
+        @Test
+        void shouldAllowSkippingHealthCheckRegistration(SoftAssertions softly) {
+            var builder = ErrorContextBuilder.newInstance()
+                    .skipHealthCheck()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .dataStoreType(DataStoreType.NOT_SHARED);
+
+            assertNoHealthCheck(softly, builder.buildInMemoryH2());
+
+            var dataSourceFactory = ApplicationErrorJdbc.createInMemoryH2Database();
+            assertNoHealthCheck(softly, builder.buildWithDataStoreFactory(dataSourceFactory));
+
+            var jdbi = Jdbi3Builders.buildManagedJdbi(environment, dataSourceFactory);
+            assertNoHealthCheck(softly, builder.buildWithJdbi3(jdbi));
+        }
+
+        private void assertNoHealthCheck(SoftAssertions softly, ErrorContext errorContext) {
+            softly.assertThat(errorContext.recentErrorsHealthCheck()).isEmpty();
+        }
+
+        @Nested
+        class TimeWindowInBuilder {
+
+            @Test
+            void shouldIgnoreNullArgument(SoftAssertions softly) {
+                var builder = ErrorContextBuilder.newInstance()
+                        .environment(environment)
+                        .serviceDetails(serviceDetails)
+                        .dataStoreType(DataStoreType.NOT_SHARED)
+                        .timeWindow(null);
+
+                assertDefaultTimeWindow(softly, builder.buildInMemoryH2());
+
+                var dataSourceFactory = ApplicationErrorJdbc.createInMemoryH2Database();
+                assertDefaultTimeWindow(softly, builder.buildWithDataStoreFactory(dataSourceFactory));
+
+                var jdbi = Jdbi3Builders.buildManagedJdbi(environment, dataSourceFactory);
+                assertDefaultTimeWindow(softly, builder.buildWithJdbi3(jdbi));
+            }
+
+            @Test
+            void shouldOverrideTimeWindowValueAndUnit(SoftAssertions softly) {
+                var builder = ErrorContextBuilder.newInstance()
+                        .environment(environment)
+                        .serviceDetails(serviceDetails)
+                        .dataStoreType(DataStoreType.NOT_SHARED)
+                        .timeWindow(new TimeWindow(Duration.hours(1)))
+                        .timeWindowValue(45)
+                        .timeWindowUnit(ChronoUnit.MINUTES);
+
+                var expectedAmount = 60;
+                var expectedUnit = ChronoUnit.MINUTES;
+
+                assertTimeWindow(softly, builder.buildInMemoryH2(), expectedAmount, expectedUnit);
+
+                var dataSourceFactory = ApplicationErrorJdbc.createInMemoryH2Database();
+                assertTimeWindow(softly, builder.buildWithDataStoreFactory(dataSourceFactory), expectedAmount, expectedUnit);
+
+                var jdbi = Jdbi3Builders.buildManagedJdbi(environment, dataSourceFactory);
+                assertTimeWindow(softly, builder.buildWithJdbi3(jdbi), expectedAmount, expectedUnit);
+            }
+        }
+
+        private void assertDefaultTimeWindow(SoftAssertions softly, ErrorContext errorContext) {
+            assertTimeWindow(softly, errorContext, TimeWindow.DEFAULT_TIME_WINDOW_MINUTES, ChronoUnit.MINUTES);
+        }
+
+        private void assertTimeWindow(SoftAssertions softly,
+                                      ErrorContext errorContext,
+                                      long timeWindowAmount,
+                                      TemporalUnit timeWindowUnit) {
+            var healthCheck = errorContext.recentErrorsHealthCheck().orElseThrow();
+            softly.assertThat(healthCheck.getTimeWindowAmount()).isEqualTo(timeWindowAmount);
+            softly.assertThat(healthCheck.getTimeWindowUnit()).isEqualTo(timeWindowUnit);
+        }
+    }
+
+    @Nested
+    class DataStoreTypeInBuilder {
+
+        @Test
+        void shouldIgnoreNullArguments() {
+            var errorContext = ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .dataStoreType(null).buildInMemoryH2();
+
+            assertThat(errorContext.dataStoreType()).isEqualTo(DataStoreType.NOT_SHARED);
+        }
+    }
+
+    @Nested
+    class BuildInMemoryH2 {
+
+        @Test
+        void shouldBuildJdbi3Context(SoftAssertions softly) {
+            var errorContext = ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .buildInMemoryH2();
+
+            softly.assertThat(errorContext).isExactlyInstanceOf(Jdbi3ErrorContext.class);
+            softly.assertThat(errorContext.errorDao()).isInstanceOf(Jdbi3ApplicationErrorDao.class);
+        }
+
+        @Test
+        void shouldRegisterResources() {
+            ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .buildInMemoryH2();
+
+            verifyRegistersJerseyResources();
+        }
+
+        @Test
+        void shouldRegisterHealthCheck() {
+            ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .buildInMemoryH2();
+
+            verifyRegistersHealthChecks();
+        }
+
+        @Test
+        void shouldForce_NOT_SHARED_DataStoreType() {
+            var errorContext = ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .dataStoreType(DataStoreType.SHARED)
+                    .buildInMemoryH2();
+
+            assertThat(errorContext.dataStoreType()).isEqualTo(DataStoreType.NOT_SHARED);
+        }
+    }
+
+    @Nested
+    class BuildWithDataStoreFactory {
+
+        private DataSourceFactory dataSourceFactory;
+
+        @BeforeEach
+        void setUp() {
+            dataSourceFactory = ApplicationErrorJdbc.createInMemoryH2Database();
+        }
+
+        @Test
+        void shouldBuildJdbi3Context(SoftAssertions softly) {
+            var errorContext = ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .buildWithDataStoreFactory(dataSourceFactory);
+
+            softly.assertThat(errorContext).isExactlyInstanceOf(Jdbi3ErrorContext.class);
+            softly.assertThat(errorContext.errorDao()).isInstanceOf(Jdbi3ApplicationErrorDao.class);
+        }
+
+        @Test
+        void shouldRegisterResources() {
+            ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .buildWithDataStoreFactory(dataSourceFactory);
+
+            verifyRegistersJerseyResources();
+        }
+
+        @Test
+        void shouldRegisterHealthCheck() {
+            ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .buildWithDataStoreFactory(dataSourceFactory);
+
+            verifyRegistersHealthChecks();
+        }
+
+        @Test
+        void shouldDetermineDataStoreTypeIfNotSet() {
+            var errorContext = ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .buildWithDataStoreFactory(dataSourceFactory);
+
+            assertThat(errorContext.dataStoreType()).isEqualTo(DataStoreType.NOT_SHARED);
+        }
+
+        @Test
+        void shouldForce_NOT_SHARED_ForH2Databases() {
+            var errorContext = ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .dataStoreType(DataStoreType.SHARED)
+                    .buildWithDataStoreFactory(dataSourceFactory);
+
+            assertThat(errorContext.dataStoreType()).isEqualTo(DataStoreType.NOT_SHARED);
+        }
+
+        @Test
+        void shouldWorkWithPostgres(SoftAssertions softly) {
+            var postgresDataSourceFactory = newPostgresDataSourceFactory();
+
+            var errorContext = ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .buildWithDataStoreFactory(postgresDataSourceFactory);
+
+            softly.assertThat(errorContext.dataStoreType()).isEqualTo(DataStoreType.SHARED);
+            softly.assertThat(errorContext.errorDao()).isNotNull();
+        }
+    }
+
+    @Nested
+    class BuildWithJdbi3 {
+
+        private Jdbi jdbi;
+
+        @BeforeEach
+        void setUp() {
+            var dataSourceFactory = ApplicationErrorJdbc.createInMemoryH2Database();
+            jdbi = Jdbi3Builders.buildManagedJdbi(environment, dataSourceFactory);
+        }
+
+        @Test
+        void shouldBuildJdbi3Context(SoftAssertions softly) {
+            var errorContext = ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .buildWithJdbi3(jdbi);
+
+            softly.assertThat(errorContext).isExactlyInstanceOf(Jdbi3ErrorContext.class);
+            softly.assertThat(errorContext.errorDao()).isInstanceOf(Jdbi3ApplicationErrorDao.class);
+        }
+
+        @Test
+        void shouldRegisterResources() {
+            ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .buildWithJdbi3(jdbi);
+
+            verifyRegistersJerseyResources();
+        }
+
+        @Test
+        void shouldRegisterHealthCheck() {
+            ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .buildWithJdbi3(jdbi);
+
+            verifyRegistersHealthChecks();
+        }
+
+        @Test
+        void shouldAcceptDataStoreType() {
+            var errorContext = ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .dataStoreType(DataStoreType.SHARED)
+                    .buildWithJdbi3(jdbi);
+
+            assertThat(errorContext.dataStoreType()).isEqualTo(DataStoreType.SHARED);
+        }
+
+        @Test
+        void shouldSetDataStoreTypeTo_SHARED_IfNotAlreadySet() {
+            var errorContext = ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .buildWithJdbi3(jdbi);
+
+            assertThat(errorContext.dataStoreType()).isEqualTo(DataStoreType.SHARED);
+        }
+
+        @Test
+        void shouldWorkWithPostgres(SoftAssertions softly) {
+            var dataSourceFactory = newPostgresDataSourceFactory();
+            var postgresJdbi = Jdbi3Builders.buildManagedJdbi(environment, dataSourceFactory);
+
+            var errorContext = ErrorContextBuilder.newInstance()
+                    .environment(environment)
+                    .serviceDetails(serviceDetails)
+                    .buildWithJdbi3(postgresJdbi);
+
+            softly.assertThat(errorContext.dataStoreType()).isEqualTo(DataStoreType.SHARED);
+            softly.assertThat(errorContext.errorDao()).isNotNull();
+        }
+    }
+
+    private static DataSourceFactory newPostgresDataSourceFactory() {
+        var dataSourceFactory = new DataSourceFactory();
+        dataSourceFactory.setDriverClass(Driver.class.getName());
+        dataSourceFactory.setUrl(POSTGRES.getTestDataSource().getUrl());
+        dataSourceFactory.setUser(POSTGRES.getTestDataSource().getUsername());
+        dataSourceFactory.setPassword(POSTGRES.getTestDataSource().getPassword());
+        return dataSourceFactory;
+    }
+
+    private void verifyRegistersJerseyResources() {
+        var jersey = environment.jersey();
+
+        verify(jersey).register(isA(ApplicationErrorResource.class));
+        verify(jersey).register(isA(GotErrorsResource.class));
+        verifyNoMoreInteractions(jersey);
+    }
+
+    private void verifyRegistersHealthChecks() {
+        var healthChecks = environment.healthChecks();
+        verify(healthChecks).register(eq("recentApplicationErrors"), isA(RecentErrorsHealthCheck.class));
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/error/ErrorContextUtilitiesTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/ErrorContextUtilitiesTest.java
@@ -54,7 +54,7 @@ class ErrorContextUtilitiesTest {
         @Test
         void shouldNotThrowException_GivenValidArguments() {
             assertThatCode(() ->
-                    ErrorContextUtilities.checkCommonArguments(environment, serviceDetails, 10, ChronoUnit.MINUTES))
+                    ErrorContextUtilities.checkCommonArguments(environment, serviceDetails, DataStoreType.SHARED, 10, ChronoUnit.MINUTES))
                     .doesNotThrowAnyException();
         }
 
@@ -62,14 +62,21 @@ class ErrorContextUtilitiesTest {
         void shouldThrowIllegalArgumentException_GivenNullEnvironment() {
             assertThatIllegalArgumentException()
                     .isThrownBy(() ->
-                            ErrorContextUtilities.checkCommonArguments(null, serviceDetails, 15, ChronoUnit.MINUTES));
+                            ErrorContextUtilities.checkCommonArguments(null, serviceDetails, DataStoreType.SHARED, 15, ChronoUnit.MINUTES));
         }
 
         @Test
         void shouldThrowIllegalArgumentException_GivenNullServiceDetails() {
             assertThatIllegalArgumentException()
                     .isThrownBy(() ->
-                            ErrorContextUtilities.checkCommonArguments(environment, null, 15, ChronoUnit.MINUTES));
+                            ErrorContextUtilities.checkCommonArguments(environment, null, DataStoreType.NOT_SHARED, 15, ChronoUnit.MINUTES));
+        }
+
+        @Test
+        void shouldThrowIllegalArgumentException_GivenNullDataStoreType() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() ->
+                            ErrorContextUtilities.checkCommonArguments(environment, serviceDetails, null, 15, ChronoUnit.MINUTES));
         }
 
         @ParameterizedTest
@@ -77,14 +84,14 @@ class ErrorContextUtilitiesTest {
         void shouldThrowIllegalArgumentException_GivenZeroOrNegativeTimeWindowValue(long value) {
             assertThatIllegalArgumentException()
                     .isThrownBy(() ->
-                            ErrorContextUtilities.checkCommonArguments(environment, serviceDetails, value, ChronoUnit.MINUTES));
+                            ErrorContextUtilities.checkCommonArguments(environment, serviceDetails, DataStoreType.SHARED, value, ChronoUnit.MINUTES));
         }
 
         @Test
         void shouldThrowIllegalArgumentException_GivenNullTimeWindowUnit() {
             assertThatIllegalArgumentException()
                     .isThrownBy(() ->
-                            ErrorContextUtilities.checkCommonArguments(environment, serviceDetails, 15, null));
+                            ErrorContextUtilities.checkCommonArguments(environment, serviceDetails, DataStoreType.SHARED, 15, null));
         }
     }
 


### PR DESCRIPTION
* Add ErrorContextBuilder for building ErrorContext objects
* Change ApplicationErrorJdbc#dataStoreTypeOf to use the isH2DataStore
  method since it does the exact same thing that this method was doing
  (i.e. make it DRY)
* Add dataStoreType arg to ErrorContextUtilities#checkCommonArguments
* Update Jdbi3ErrorContext to supply dataStoreType to call to
  checkCommonArguments
* Fix TODOs in Javadocs in ApplicationError and ErrorContext

Fixes #38