### PR TITLE
Fix the H2 dependency version in the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <metrics-healthchecks-severity.version>0.10.1</metrics-healthchecks-severity.version>
 
         <!-- Versions for provided dependencies -->
-        <h2.version>&gt;1.4.200</h2.version>
+        <h2.version>1.4.200</h2.version>
         <liquibase.version>3.8.9</liquibase.version>
 
         <!-- Versions for optional dependencies -->


### PR DESCRIPTION
Remove the &gt; from before the version...was not intentional.

Fixes #43