### PR TITLE
Update parent POM and kiwi dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.0</version>
     </parent>
 
     <artifactId>dropwizard-application-errors</artifactId>
@@ -38,8 +38,8 @@
         <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
         <javassist.version>3.27.0-GA</javassist.version>
         <joda-time.version>2.10.7</joda-time.version>
-        <kiwi.version>0.15.0</kiwi.version>
-        <metrics-healthchecks-severity.version>0.12.1</metrics-healthchecks-severity.version>
+        <kiwi.version>0.16.0</kiwi.version>
+        <metrics-healthchecks-severity.version>0.13.0</metrics-healthchecks-severity.version>
         <metrics-jetty9.version>4.1.14</metrics-jetty9.version>
 
         <!-- Versions for provided dependencies -->
@@ -51,7 +51,7 @@
 
         <!-- Versions for test dependencies -->
         <embedded-postgres.version>1.2.6</embedded-postgres.version>
-        <kiwi-test.version>0.10.0</kiwi-test.version>
+        <kiwi-test.version>0.11.0</kiwi-test.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_dropwizard-application-errors</sonar.projectKey>


### PR DESCRIPTION
* Bump kiwi-parent to 0.4.0
* Bump kiwi to 0.16.0
* Bump kiwi-test to 0.11.0
* Bump metrics-healthchecks-severity to 0.13.0

Fixes #50
Fixes #51
Fixes #52
Fixes #53