### PR TITLE
Indicate via javadoc and annotations when Throwable args can be null

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/ApplicationErrorThrower.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/ApplicationErrorThrower.java
@@ -8,6 +8,7 @@ import org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao;
 import org.kiwiproject.dropwizard.error.model.ApplicationError;
 import org.slf4j.Logger;
 
+import javax.annotation.Nullable;
 import java.util.OptionalLong;
 
 /**
@@ -62,11 +63,11 @@ public class ApplicationErrorThrower {
     /**
      * Log and save an {@link ApplicationError} with the given {@link Throwable} and message.
      *
-     * @param throwable the underlying cause of the application error
+     * @param throwable the underlying cause of the application error (can be null)
      * @param message   a description of the problem that occurred
      * @return an OptionalLong containing the ID of the saved ApplicationError, or empty if a problem occurred saving
      */
-    public OptionalLong logAndSaveApplicationError(Throwable throwable, String message) {
+    public OptionalLong logAndSaveApplicationError(@Nullable Throwable throwable, String message) {
         return ApplicationErrors.logAndSaveApplicationError(errorDao, logger, throwable, message);
     }
 
@@ -74,13 +75,13 @@ public class ApplicationErrorThrower {
      * Log and save an {@link ApplicationError} with the given {@link Throwable} and parameterized message
      * using the supplied message arguments.
      *
-     * @param throwable       the underlying cause of the application error
+     * @param throwable       the underlying cause of the application error (can be null)
      * @param messageTemplate a template for the description of the problem that occurred, formatted
      *                        using {@link KiwiStrings#format(String, Object...)}
      * @param args            the arguments to supply to the message template
      * @return an OptionalLong containing the ID of the saved ApplicationError, or empty if a problem occurred saving
      */
-    public OptionalLong logAndSaveApplicationError(Throwable throwable, String messageTemplate, Object... args) {
+    public OptionalLong logAndSaveApplicationError(@Nullable Throwable throwable, String messageTemplate, Object... args) {
         return ApplicationErrors.logAndSaveApplicationError(errorDao, logger, throwable, messageTemplate, args);
     }
 }

--- a/src/main/java/org/kiwiproject/dropwizard/error/ApplicationErrors.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/ApplicationErrors.java
@@ -9,6 +9,7 @@ import org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao;
 import org.kiwiproject.dropwizard.error.model.ApplicationError;
 import org.slf4j.Logger;
 
+import javax.annotation.Nullable;
 import java.util.OptionalLong;
 
 /**
@@ -73,7 +74,7 @@ public class ApplicationErrors {
      *
      * @param errorDao        an ApplicationErrorDao that can store application errors
      * @param logger          the SLF4J logger to use when logging
-     * @param throwable       the underlying cause of the application error
+     * @param throwable       the underlying cause of the application error (can be null)
      * @param messageTemplate a template for the description of the problem that occurred, formatted
      *                        using {@link KiwiStrings#format(String, Object...)}
      * @param args            the arguments to supply to the message template
@@ -81,7 +82,7 @@ public class ApplicationErrors {
      */
     public static OptionalLong logAndSaveApplicationError(ApplicationErrorDao errorDao,
                                                           Logger logger,
-                                                          Throwable throwable,
+                                                          @Nullable Throwable throwable,
                                                           String messageTemplate,
                                                           Object... args) {
         var errorMessage = KiwiStrings.format(messageTemplate, args);
@@ -94,13 +95,13 @@ public class ApplicationErrors {
      *
      * @param errorDao  an ApplicationErrorDao that can store application errors
      * @param logger    the SLF4J logger to use when logging
-     * @param throwable the underlying cause of the application error
+     * @param throwable the underlying cause of the application error (can be null)
      * @param message   a description of the problem that occurred
      * @return an OptionalLong containing the ID of the saved ApplicationError, or empty if a problem occurred saving
      */
     public static OptionalLong logAndSaveApplicationError(ApplicationErrorDao errorDao,
                                                           Logger logger,
-                                                          Throwable throwable,
+                                                          @Nullable Throwable throwable,
                                                           String message) {
         try {
             logger.error(message, throwable);
@@ -115,11 +116,11 @@ public class ApplicationErrors {
     /**
      * @param saveException     the exception that was thrown when we tried to save the ApplicationError
      * @param appErrorMessage   the message from the ApplicationError that we tried (and failed) to save
-     * @param appErrorThrowable the Throwable from the ApplicationError that we tried (and failed) to save
+     * @param appErrorThrowable the Throwable from the ApplicationError that we tried (and failed) to save (can be null)
      */
     private static void logErrorSavingApplicationError(Exception saveException,
                                                        String appErrorMessage,
-                                                       Throwable appErrorThrowable) {
+                                                       @Nullable Throwable appErrorThrowable) {
         if (nonNull(appErrorThrowable)) {
             LOG.error("Error saving ApplicationError with description [{}] and {} exception having message: {}.",
                     appErrorMessage,

--- a/src/test/java/org/kiwiproject/dropwizard/error/ApplicationErrorThrowerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/ApplicationErrorThrowerTest.java
@@ -142,6 +142,22 @@ class ApplicationErrorThrowerTest {
         class WithThrowableAndMessage {
 
             @Test
+            void shouldPermitNullThrowable(SoftAssertions softly) {
+                var id = 142L;
+                when(errorDao.insertOrIncrementCount(any())).thenReturn(id);
+
+                var optionalId = errorThrower.logAndSaveApplicationError(null, "A simple message");
+
+                softly.assertThat(optionalId).hasValue(id);
+                verify(errorDao).insertOrIncrementCount(argThat(error -> {
+                    softly.assertThat(error.getDescription()).isEqualTo("A simple message");
+                    softly.assertThat(error.getExceptionType()).isNull();
+                    softly.assertThat(error.getExceptionMessage()).isNull();
+                    return true;
+                }));
+            }
+
+            @Test
             void shouldSaveApplicationError(SoftAssertions softly) {
                 var id = 168L;
                 when(errorDao.insertOrIncrementCount(any())).thenReturn(id);
@@ -172,6 +188,22 @@ class ApplicationErrorThrowerTest {
 
         @Nested
         class WithThrowableAndParameterizedMessage {
+
+            @Test
+            void shouldPermitNullThrowable(SoftAssertions softly) {
+                var id = 442L;
+                when(errorDao.insertOrIncrementCount(any())).thenReturn(id);
+
+                var optionalId = errorThrower.logAndSaveApplicationError((Throwable) null, MESSAGE_TEMPLATE, 336, "anodyne");
+
+                softly.assertThat(optionalId).hasValue(id);
+                verify(errorDao).insertOrIncrementCount(argThat(error -> {
+                    softly.assertThat(error.getDescription()).isEqualTo("A parameterized message with answer 336 and random word anodyne");
+                    softly.assertThat(error.getExceptionType()).isNull();
+                    softly.assertThat(error.getExceptionMessage()).isNull();
+                    return true;
+                }));
+            }
 
             @Test
             void shouldSaveApplicationError(SoftAssertions softly) {
@@ -231,4 +263,13 @@ class ApplicationErrorThrowerTest {
     // adjective
     // (of a product) made or used as a substitute, typically an inferior one, for something else
     // - not real or genuine
+
+    // anodyne:
+    // adjective
+    // 1. serving to alleviate pain
+    // 2. not likely to offend or arouse tensions, innocuous
+    //
+    // noun
+    // 1. something that soothes, calms, or comforts
+    // 2. a drug that allays pain
 }


### PR DESCRIPTION
* Add Nullable annotation to Throwable arguments that allow null in
  both ApplicationErrors and ApplicationErrorThrower
* Indicate when Throwable arguments can be null in Javadocs in both
  ApplicationErrors and ApplicationErrorThrower

Closes #68