### PR TITLE
Make dropwizard-jdbi3 have compile scope in the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,6 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-jdbi3</artifactId>
             <version>${dropwizard.version}</version>
-            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>com.github.ben-manes.caffeine</groupId>


### PR DESCRIPTION
* Remove provided scope declaration for dropwizard-jdbi3 in the POM
  thereby making it compile (the default) scope

Fixes #71