### PR TITLE
Fix misnamed property in CleanupConfig

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/config/CleanupConfig.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/config/CleanupConfig.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * Configuration class used to setup the {@link org.kiwiproject.dropwizard.error.job.CleanupApplicationErrorsJob}
+ * Configuration class used to set up the {@link org.kiwiproject.dropwizard.error.job.CleanupApplicationErrorsJob}
  */
 @Getter
 @Setter
@@ -36,7 +36,7 @@ public class CleanupConfig {
     /**
      * The duration that an unresolved error will live before being deleted.
      */
-    private Duration unresolvedErrorException = Duration.days(60);
+    private Duration unresolvedErrorExpiration = Duration.days(60);
 
     /**
      * The name to give the scheduled job for cleaning up errors. Defaults to {@code Application-Errors-Cleanup-Job-%d}

--- a/src/main/java/org/kiwiproject/dropwizard/error/job/CleanupApplicationErrorsJob.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/job/CleanupApplicationErrorsJob.java
@@ -26,7 +26,7 @@ public class CleanupApplicationErrorsJob implements CatchingRunnable {
     public CleanupApplicationErrorsJob(CleanupConfig config, ApplicationErrorDao errorDao) {
         this.config = config;
         this.resolvedErrorExpirationMinutes = config.getResolvedErrorExpiration().toMinutes();
-        this.unresolvedErrorExpirationMinutes = config.getUnresolvedErrorException().toMinutes();
+        this.unresolvedErrorExpirationMinutes = config.getUnresolvedErrorExpiration().toMinutes();
         this.errorDao = errorDao;
 
         checkPositive(resolvedErrorExpirationMinutes, "resolvedErrorExpiration must be at least one minute");

--- a/src/test/java/org/kiwiproject/dropwizard/error/config/CleanupConfigTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/config/CleanupConfigTest.java
@@ -15,6 +15,6 @@ class CleanupConfigTest {
 
         assertThat(config.getCleanupStrategy()).isEqualTo(CleanupConfig.CleanupStrategy.ALL_ERRORS);
         assertThat(config.getResolvedErrorExpiration()).isEqualTo(Duration.days(14));
-        assertThat(config.getUnresolvedErrorException()).isEqualTo(Duration.days(60));
+        assertThat(config.getUnresolvedErrorExpiration()).isEqualTo(Duration.days(60));
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/error/job/CleanupApplicationErrorsJobTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/job/CleanupApplicationErrorsJobTest.java
@@ -41,7 +41,7 @@ class CleanupApplicationErrorsJobTest {
     @Test
     void shouldRequireUnresolvedExpirationOfAtLeastOneMinute() {
         var config = new CleanupConfig();
-        config.setUnresolvedErrorException(Duration.seconds(59));
+        config.setUnresolvedErrorExpiration(Duration.seconds(59));
 
         assertThatIllegalStateException()
                 .isThrownBy(() -> new CleanupApplicationErrorsJob(config, dao))
@@ -62,7 +62,7 @@ class CleanupApplicationErrorsJobTest {
         LOG.debug("Expecting resolved threshold: {}", expectedResolvedThreshold);
         verify(dao).deleteResolvedErrorsBefore(argThat(time -> time.isBefore(expectedResolvedThreshold)));
 
-        var expectedUnresolvedThreshold = now.minusMinutes(config.getUnresolvedErrorException().toMinutes());
+        var expectedUnresolvedThreshold = now.minusMinutes(config.getUnresolvedErrorExpiration().toMinutes());
         LOG.debug("Expecting unresolved threshold: {}", expectedUnresolvedThreshold);
         verify(dao).deleteUnresolvedErrorsBefore(argThat(time -> time.isBefore(expectedUnresolvedThreshold)));
     }
@@ -75,7 +75,7 @@ class CleanupApplicationErrorsJobTest {
         var job = new CleanupApplicationErrorsJob(config, dao);
         job.run();
 
-        var expectedResolvedThreshold = ZonedDateTime.now().minusMinutes(Duration.days(14).toMinutes());
+        var expectedResolvedThreshold = ZonedDateTime.now().minusMinutes(config.getResolvedErrorExpiration().toMinutes());
         LOG.debug("Expecting resolved threshold: {}", expectedResolvedThreshold);
         verify(dao).deleteResolvedErrorsBefore(argThat(time -> time.isBefore(expectedResolvedThreshold)));
 


### PR DESCRIPTION
* Rename unresolvedErrorException to unresolvedErrorExpiration
* Fix grammatical error (change 'setup' to 'set up')
* Change hard-coded Duration in CleanupApplicationErrorsJobTest to use
  the value from the CleanupConfig (I missed one this in my last PR)

Closes #108