### PR TITLE
Remove 'p' tag from CleanupConfig javadoc that caused a warning

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/config/CleanupConfig.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/config/CleanupConfig.java
@@ -13,7 +13,6 @@ public class CleanupConfig {
 
     /**
      * Strategies for what should be cleaned up.
-     * <p>
      * <ul>
      *     <li>ALL_ERRORS - Will remove resolved AND unresolved errors older than {@code applicationErrorExpiration}</li>
      *     <li>RESOLVED_ONLY - Will remove resolved errors older than {@code applicationErrorExpiration}</li>


### PR DESCRIPTION
Javadoc was giving the following warning: warning: empty <p> tag

I guess it didn't like that there was a 'ul' tag immediately following
the 'p' tag
