### PR TITLE
Remove obsolete 'Rotten Tomato' from an exception message

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbc.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbc.java
@@ -81,7 +81,7 @@ public class ApplicationErrorJdbc {
                 conn.setAutoCommit(originalAutoCommit);
             }
         } catch (Exception e) {
-            var message = format("Error migrating {} database for Rotten Tomato", getDatabaseProductNameOrUnknown(conn));
+            var message = format("Error migrating {} database", getDatabaseProductNameOrUnknown(conn));
             throw new ApplicationErrorJdbcException(message, e);
         }
     }

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbcTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbcTest.java
@@ -120,7 +120,7 @@ class ApplicationErrorJdbcTest {
 
             assertThatThrownBy(() -> ApplicationErrorJdbc.migrateDatabase(conn))
                     .isExactlyInstanceOf(ApplicationErrorJdbc.ApplicationErrorJdbcException.class)
-                    .hasMessage("Error migrating [Unknown Error] database for Rotten Tomato");
+                    .hasMessage("Error migrating [Unknown Error] database");
         }
     }
 


### PR DESCRIPTION
The original name of this library was rotten-tomato. We removed or
renamed most of the references, but missed this one.