### PR TITLE
Update 'see' javadoc tag in CleanupApplicationErrorsJob

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/job/CleanupApplicationErrorsJob.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/job/CleanupApplicationErrorsJob.java
@@ -13,7 +13,7 @@ import java.time.ZonedDateTime;
 /**
  * Job that can be configured to run on a regular interval that will delete expired application errors.
  *
- * @see CleanupConfig for options on what will be deleted and when
+ * @see CleanupConfig configuration options on what will be deleted and when
  */
 @Slf4j
 public class CleanupApplicationErrorsJob implements CatchingRunnable {


### PR DESCRIPTION
Fix the 'see' tag in CleanupApplicationErrorsJob javadoc so that the label makes sense.

Currently the text in the javadoc is just "for options on..." since the class name is not included when the javadoc is generated.