### PR TITLE
Add support in ErrorContextBuilder for no-op and concurrent map DAOs

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/ErrorContext.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/ErrorContext.java
@@ -8,7 +8,8 @@ import java.util.Optional;
 
 /**
  * This library provides an easy way to store application errors in your service's local (e.g. Postgres) database.
- * This interface defines the general contract, and instances are built using {@link ErrorContextBuilder}.
+ * This interface defines the general contract, and instances are usually built using {@link ErrorContextBuilder},
+ * though you can build everything programmatically if you want to.
  * <p>
  * This acts much like a Dropwizard bundle in that it creates an {@link ApplicationErrorDao} for use anywhere in
  * your application, and registers an
@@ -21,7 +22,9 @@ import java.util.Optional;
  * {@link ErrorContextBuilder#skipHealthCheck()} when constructing the instance.
  * <p>
  * We currently support storing errors to a relational database with JDBI 3. If your application does not currently
- * have a database or uses something else, then we also provide an option to use an in-memory H2 database.
+ * have a database or uses something else, we also provide several other options including an in-memory H2 database,
+ * an in-memory implementation that uses a {@link java.util.concurrent.ConcurrentMap} and a no-op implementation
+ * that does nothing.
  * <p>
  * <strong>JDBI Note:</strong>
  * To start creating application errors you will first need to create the database

--- a/src/main/java/org/kiwiproject/dropwizard/error/ErrorContextUtilities.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/ErrorContextUtilities.java
@@ -35,7 +35,7 @@ class ErrorContextUtilities {
 
         checkArgumentNotNull(environment, "Dropwizard Environment cannot be null");
         checkArgumentNotNull(serviceDetails, "serviceDetails cannot be null");
-        checkArgumentNotNull(dataStoreType, "dataStoreType cannot ne null");
+        checkArgumentNotNull(dataStoreType, "dataStoreType cannot be null");
         checkArgument(timeWindowValue > 0, "timeWindowValue must be positive");
         checkArgumentNotNull(timeWindowUnit, "timeWindowUnit cannot be null");
     }

--- a/src/main/java/org/kiwiproject/dropwizard/error/SimpleErrorContext.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/SimpleErrorContext.java
@@ -1,0 +1,68 @@
+package org.kiwiproject.dropwizard.error;
+
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+import static org.kiwiproject.dropwizard.error.ErrorContextUtilities.checkCommonArguments;
+import static org.kiwiproject.dropwizard.error.ErrorContextUtilities.registerCleanupJobOrNull;
+import static org.kiwiproject.dropwizard.error.ErrorContextUtilities.registerRecentErrorsHealthCheckOrNull;
+import static org.kiwiproject.dropwizard.error.ErrorContextUtilities.registerResources;
+import static org.kiwiproject.dropwizard.error.ErrorContextUtilities.setPersistentHostInformationFrom;
+
+import io.dropwizard.setup.Environment;
+import org.kiwiproject.dropwizard.error.config.CleanupConfig;
+import org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao;
+import org.kiwiproject.dropwizard.error.health.RecentErrorsHealthCheck;
+import org.kiwiproject.dropwizard.error.model.DataStoreType;
+import org.kiwiproject.dropwizard.error.model.ServiceDetails;
+
+import java.time.temporal.TemporalUnit;
+import java.util.Optional;
+
+/**
+ * A "simple" implementation of {@link ErrorContext} that accepts an {@link ApplicationErrorDao} instance.
+ *
+ * @implNote This class is not public and is subject to change.
+ */
+class SimpleErrorContext implements ErrorContext {
+
+    private final ApplicationErrorDao errorDao;
+    private final DataStoreType dataStoreType;
+    private final RecentErrorsHealthCheck healthCheck;
+
+    public SimpleErrorContext(Environment environment,
+                              ServiceDetails serviceDetails,
+                              ApplicationErrorDao errorDao,
+                              DataStoreType dataStoreType,
+                              boolean addHealthCheck,
+                              long timeWindowValue,
+                              TemporalUnit timeWindowUnit,
+                              boolean addCleanupJob,
+                              CleanupConfig cleanupConfig) {
+
+        checkCommonArguments(environment, serviceDetails, dataStoreType, timeWindowValue, timeWindowUnit);
+        checkArgumentNotNull(errorDao, "ApplicationErrorDao must not be null");
+        setPersistentHostInformationFrom(serviceDetails);
+
+        this.errorDao = errorDao;
+        this.dataStoreType = dataStoreType;
+        this.healthCheck = registerRecentErrorsHealthCheckOrNull(
+                addHealthCheck, environment, errorDao, serviceDetails, timeWindowValue, timeWindowUnit);
+
+        registerCleanupJobOrNull(addCleanupJob, environment, errorDao, cleanupConfig);
+        registerResources(environment, errorDao, dataStoreType);
+    }
+
+    @Override
+    public DataStoreType dataStoreType() {
+        return dataStoreType;
+    }
+
+    @Override
+    public ApplicationErrorDao errorDao() {
+        return errorDao;
+    }
+
+    @Override
+    public Optional<RecentErrorsHealthCheck> recentErrorsHealthCheck() {
+        return Optional.ofNullable(healthCheck);
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/error/SimpleErrorContextTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/SimpleErrorContextTest.java
@@ -1,0 +1,123 @@
+package org.kiwiproject.dropwizard.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.dropwizard.setup.Environment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.dropwizard.error.config.CleanupConfig;
+import org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao;
+import org.kiwiproject.dropwizard.error.dao.jdk.NoOpApplicationErrorDao;
+import org.kiwiproject.dropwizard.error.health.RecentErrorsHealthCheck;
+import org.kiwiproject.dropwizard.error.model.ApplicationError;
+import org.kiwiproject.dropwizard.error.model.DataStoreType;
+import org.kiwiproject.dropwizard.error.model.ServiceDetails;
+import org.kiwiproject.dropwizard.error.resource.ApplicationErrorResource;
+import org.kiwiproject.dropwizard.error.resource.GotErrorsResource;
+import org.kiwiproject.test.dropwizard.mockito.DropwizardMockitoMocks;
+
+import java.time.temporal.ChronoUnit;
+
+@DisplayName("SimpleErrorContext")
+class SimpleErrorContextTest {
+
+    private Environment environment;
+    private ServiceDetails serviceDetails;
+
+    private ApplicationErrorDao errorDao;
+    private DataStoreType dataStoreType;
+    private long timeWindowAmount;
+    private ChronoUnit timeWindowUnit;
+
+    private SimpleErrorContext context;
+
+    @BeforeEach
+    void setUp() {
+        environment = DropwizardMockitoMocks.mockEnvironment();
+        serviceDetails = new ServiceDetails("localhost", "127.0.0.1", 8080);
+        errorDao = new NoOpApplicationErrorDao();
+        dataStoreType = DataStoreType.NOT_SHARED;
+        timeWindowAmount = 1;
+        timeWindowUnit = ChronoUnit.HOURS;
+    }
+
+    @AfterEach
+    void tearDown() {
+        ApplicationError.clearPersistentHostInformation();
+    }
+
+    @Nested
+    class ConstructorAddingHealthCheck {
+
+        @BeforeEach
+        void setUp() {
+            context = newContextWithAddHealthCheckOf(true);
+        }
+
+        @Test
+        void shouldRegisterHealthCheck() {
+            assertThat(context.recentErrorsHealthCheck()).isPresent();
+
+            var healthChecks = environment.healthChecks();
+            verify(healthChecks).register(eq("recentApplicationErrors"), isA(RecentErrorsHealthCheck.class));
+            verifyNoMoreInteractions(healthChecks);
+        }
+
+        @Test
+        void shouldSetDataStoreType() {
+            assertThat(context.dataStoreType()).isEqualTo(dataStoreType);
+        }
+
+        @Test
+        void shouldSetErrorDao() {
+            assertThat(context.errorDao()).isSameAs(errorDao);
+        }
+
+        @Test
+        void shouldRegisterResources() {
+            var jersey = environment.jersey();
+
+            verify(jersey).register(isA(ApplicationErrorResource.class));
+            verify(jersey).register(isA(GotErrorsResource.class));
+            verifyNoMoreInteractions(jersey);
+        }
+    }
+
+    @Nested
+    class ConstructorNotAddingHealthCheck {
+
+        @BeforeEach
+        void setUp() {
+            context = newContextWithAddHealthCheckOf(false);
+        }
+
+        @Test
+        void shouldNotRegisterHealthCheck() {
+            assertThat(context.recentErrorsHealthCheck()).isEmpty();
+
+            var healthChecks = environment.healthChecks();
+            verifyNoInteractions(healthChecks);
+        }
+    }
+
+    private SimpleErrorContext newContextWithAddHealthCheckOf(boolean addHealthCheck) {
+        return new SimpleErrorContext(environment,
+                serviceDetails,
+                errorDao,
+                dataStoreType,
+                addHealthCheck,
+                timeWindowAmount,
+                timeWindowUnit,
+                false,
+                new CleanupConfig()
+        );
+    }
+}


### PR DESCRIPTION
* Update javadoc in ErrorContext to reference new DAO implementations
* Add buildWithNoOpDao to ErrorContextBuilder
* Add buildWithConcurrentMapDao to ErrorContextBuilder
* Add buildWithDao to ErrorContextBuilder
* Update javadoc in ErrorContextBuilder for new DAO implementations
* Add SimpleErrorContext to support the no-op, concurrent map, and any generic DAO implementation. Keeping it package-private for now for several reasons: first, I don't like the 9 argument constructor but don't have a better idea right now; second, ErrorContextUtilities is still package-private, and so is Jdbi3ErrorContext; and third, I don't think it needs to be public at the moment. We've never once needed to access the ErrorContext implementation directly in any of our services thus far.

Closes #211
Closes #212