### PR TITLE
Use KiwiInternetAddresses to get the InetAddress for localhost

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/test/junit/jupiter/ApplicationErrorExtension.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/test/junit/jupiter/ApplicationErrorExtension.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.kiwiproject.dropwizard.error.model.ApplicationError;
 import org.kiwiproject.dropwizard.error.model.PersistentHostInformation;
+import org.kiwiproject.net.KiwiInternetAddresses;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -18,7 +19,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 
 /**
  * A JUnit Jupiter extension that ensures the {@link PersistentHostInformation} is set on {@link ApplicationError}
@@ -100,12 +100,7 @@ public class ApplicationErrorExtension implements BeforeAllCallback, AfterAllCal
     }
 
     private InetAddress getLocalHost() {
-        try {
-            return InetAddress.getLocalHost();
-        } catch (UnknownHostException e) {
-            LOG.debug("Error getting local host. Will default to loopback address", e);
-            return InetAddress.getLoopbackAddress();
-        }
+        return KiwiInternetAddresses.getLocalHostInetAddress().orElseGet(InetAddress::getLoopbackAddress);
     }
 
     @Override


### PR DESCRIPTION
This removes boilerplate and also eliminates the catch of the UnknownHostException which was not covered by tests (since it's not trivial to force the JDK InetAddress#getLocalHost to throw an UnknownHostException). Technically the orElseGet still isn't covered, but it's not worth bothering with since it is so unlikely to ever happen.

Closes #217