### PR TITLE
Just a bit more "clear box" testing

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/dao/jdk/ConcurrentMapApplicationErrorDao.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/dao/jdk/ConcurrentMapApplicationErrorDao.java
@@ -252,7 +252,8 @@ public class ConcurrentMapApplicationErrorDao implements ApplicationErrorDao {
         return updateWith(original, newNumTimesOccurred, original.isResolved());
     }
 
-    private static ApplicationError updateWith(ApplicationError original, int numTimesOccurred, boolean resolved) {
+    @VisibleForTesting
+    static ApplicationError updateWith(ApplicationError original, int numTimesOccurred, boolean resolved) {
         checkArgumentNotNull(original, "ApplicationError to update must not be null");
 
         var now = ZonedDateTime.now(ZoneOffset.UTC);

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/ConcurrentMapApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/ConcurrentMapApplicationErrorDaoTest.java
@@ -1,6 +1,7 @@
 package org.kiwiproject.dropwizard.error.dao.jdk;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -10,7 +11,11 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.kiwiproject.dropwizard.error.dao.AbstractApplicationErrorDaoTest;
 import org.kiwiproject.dropwizard.error.dao.ApplicationErrorStatus;
 import org.kiwiproject.dropwizard.error.model.ApplicationError;
+import org.kiwiproject.test.junit.jupiter.ClearBoxTest;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -61,6 +66,50 @@ class ConcurrentMapApplicationErrorDaoTest extends AbstractApplicationErrorDaoTe
         })
         void shouldReturnExpectedValue(ApplicationErrorStatus status, boolean expectedResult) {
             assertThat(ConcurrentMapApplicationErrorDao.isResolvedOrUnresolved(status)).isEqualTo(expectedResult);
+        }
+    }
+
+    @Nested
+    class UpdateWith {
+
+        @ClearBoxTest
+        void shouldSetCreatedAtIfNull_AndModifyUpdatedAt_ToNow() {
+            var originalError = ApplicationError.builder().build();
+
+            assertThat(originalError.getCreatedAt())
+                    .describedAs("precondition violated: createdAt must be null")
+                    .isNull();
+            assertThat(originalError.getUpdatedAt())
+                    .describedAs("precondition violated: updatedAt must be null")
+                    .isNull();
+
+            var updatedError = ConcurrentMapApplicationErrorDao.updateWith(originalError, 42, true);
+
+            var now = ZonedDateTime.now(ZoneOffset.UTC);
+            assertThat(updatedError.getCreatedAt()).isCloseTo(now, within(250, ChronoUnit.MILLIS));
+            assertThat(updatedError.getUpdatedAt()).isCloseTo(now, within(250, ChronoUnit.MILLIS));
+        }
+
+        @ClearBoxTest
+        void shouldUpdateResolved() {
+            var originalError = ApplicationError.builder()
+                    .numTimesOccurred(4)
+                    .build();
+
+            var updatedError = ConcurrentMapApplicationErrorDao.updateWith(originalError, 5, true);
+
+            assertThat(updatedError.getNumTimesOccurred()).isEqualTo(5);
+        }
+
+        @ClearBoxTest
+        void shouldUpdateNumTimesOccurred() {
+            var originalError = ApplicationError.builder()
+                    .resolved(false)
+                    .build();
+
+            var updatedError = ConcurrentMapApplicationErrorDao.updateWith(originalError, 5, true);
+
+            assertThat(updatedError.isResolved()).isTrue();
         }
     }
 }


### PR DESCRIPTION
Yes, this is overkill. Add test to ConcurrentMapApplicationErrorDaoTest to verify the ternary expression in the "updateWith" method when the createdAt property is null. It should not be null at this point, but add a test for this sanity check.