### PR TITLE
Update parent POM and BOM for JDK 17 and major library updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ '11', '17', '20' ]
+        java_version: [ '17', '20' ]
     steps:
       # Check out the project
       - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
       # Cache all the things
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
@@ -54,16 +54,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V compile
 
-      # Run tests when Java version > 11 (Sonar runs tests and analysis on JDK 11)
+      # Run tests when Java version > 17 (Sonar runs tests and analysis on JDK 17)
       - name: Run tests
-        if: ${{ matrix.java_version != '11' }}
+        if: ${{ matrix.java_version != '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V verify
 
-      # Run Sonar Analysis (on Java version 11 only)
+      # Run Sonar Analysis (on Java version 17 only)
       - name: Analyze with SonarCloud
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Java 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 17
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>2.0.20</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>dropwizard-application-errors</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -29,12 +29,12 @@
     <properties>
 
         <!-- Versions for required dependencies -->
-        <kiwi.version>2.7.0</kiwi.version>
-        <kiwi-bom.version>1.1.1</kiwi-bom.version>
-        <metrics-healthchecks-severity.version>1.0.13</metrics-healthchecks-severity.version>
+        <kiwi.version>3.0.0</kiwi.version>
+        <kiwi-bom.version>2.0.0</kiwi-bom.version>
+        <metrics-healthchecks-severity.version>2.0.0</metrics-healthchecks-severity.version>
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>2.4.0</kiwi-test.version>
+        <kiwi-test.version>3.0.0</kiwi-test.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_dropwizard-application-errors</sonar.projectKey>

--- a/src/main/java/org/kiwiproject/dropwizard/error/ErrorContextBuilder.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/ErrorContextBuilder.java
@@ -5,8 +5,8 @@ import static org.kiwiproject.dropwizard.error.ErrorContextUtilities.checkCommon
 import static org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc.createInMemoryH2Database;
 import static org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc.isH2DataStore;
 
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.db.DataSourceFactory;
-import io.dropwizard.setup.Environment;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.core.Jdbi;
 import org.kiwiproject.dropwizard.error.config.CleanupConfig;

--- a/src/main/java/org/kiwiproject/dropwizard/error/ErrorContextUtilities.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/ErrorContextUtilities.java
@@ -3,7 +3,7 @@ package org.kiwiproject.dropwizard.error;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import lombok.experimental.UtilityClass;
 import org.kiwiproject.dropwizard.error.config.CleanupConfig;
 import org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao;

--- a/src/main/java/org/kiwiproject/dropwizard/error/Jdbi3ErrorContext.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/Jdbi3ErrorContext.java
@@ -8,7 +8,7 @@ import static org.kiwiproject.dropwizard.error.ErrorContextUtilities.registerRec
 import static org.kiwiproject.dropwizard.error.ErrorContextUtilities.registerResources;
 import static org.kiwiproject.dropwizard.error.ErrorContextUtilities.setPersistentHostInformationFrom;
 
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.extension.NoSuchExtensionException;
 import org.kiwiproject.dropwizard.error.config.CleanupConfig;

--- a/src/main/java/org/kiwiproject/dropwizard/error/SimpleErrorContext.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/SimpleErrorContext.java
@@ -7,7 +7,7 @@ import static org.kiwiproject.dropwizard.error.ErrorContextUtilities.registerRec
 import static org.kiwiproject.dropwizard.error.ErrorContextUtilities.registerResources;
 import static org.kiwiproject.dropwizard.error.ErrorContextUtilities.setPersistentHostInformationFrom;
 
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import org.kiwiproject.dropwizard.error.config.CleanupConfig;
 import org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao;
 import org.kiwiproject.dropwizard.error.health.RecentErrorsHealthCheck;

--- a/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorDao.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorDao.java
@@ -27,19 +27,11 @@ public interface ApplicationErrorDao {
      * @return the number of errors having the given status
      */
     default long count(ApplicationErrorStatus status) {
-        switch (status) {
-            case ALL:
-                return countAllErrors();
-
-            case RESOLVED:
-                return countResolvedErrors();
-
-            case UNRESOLVED:
-                return countUnresolvedErrors();
-
-            default:
-                throw new IllegalArgumentException("Unknown error status value: " + status.name());
-        }
+        return switch (status) {
+            case ALL -> countAllErrors();
+            case RESOLVED -> countResolvedErrors();
+            case UNRESOLVED -> countUnresolvedErrors();
+        };
     }
 
     /**

--- a/src/main/java/org/kiwiproject/dropwizard/error/dao/jdbi3/Jdbi3ApplicationErrorDao.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/dao/jdbi3/Jdbi3ApplicationErrorDao.java
@@ -66,19 +66,11 @@ public interface Jdbi3ApplicationErrorDao extends ApplicationErrorDao {
 
         int offset = checkPagingArgumentsAndCalculateZeroBasedOffset(pageNumber, pageSize);
 
-        switch (status) {
-            case ALL:
-                return getAllErrorsInternal(pageSize, offset);
-
-            case RESOLVED:
-                return getErrorsInternal(true, pageSize, offset);
-
-            case UNRESOLVED:
-                return getErrorsInternal(false, pageSize, offset);
-
-            default:
-                throw new IllegalArgumentException("Unknown error status value: " + status.name());
-        }
+        return switch (status) {
+            case ALL -> getAllErrorsInternal(pageSize, offset);
+            case RESOLVED -> getErrorsInternal(true, pageSize, offset);
+            case UNRESOLVED -> getErrorsInternal(false, pageSize, offset);
+        };
     }
 
     /**

--- a/src/main/java/org/kiwiproject/dropwizard/error/dao/jdk/ConcurrentMapApplicationErrorDao.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/dao/jdk/ConcurrentMapApplicationErrorDao.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.function.Predicate.not;
-import static java.util.stream.Collectors.toList;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentIsNull;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao.checkPagingArgumentsAndCalculateZeroBasedOffset;
@@ -106,7 +105,7 @@ public class ConcurrentMapApplicationErrorDao implements ApplicationErrorDao {
                 .sorted(UPDATED_AT_DESCENDING)
                 .skip(offset)
                 .limit(pageSize)
-                .collect(toList());
+                .toList();
     }
 
     @Override
@@ -115,7 +114,7 @@ public class ConcurrentMapApplicationErrorDao implements ApplicationErrorDao {
                 .stream()
                 .filter(byStatus(ApplicationErrorStatus.UNRESOLVED))
                 .filter(error -> error.getDescription().equals(description))
-                .collect(toList());
+                .toList();
     }
 
     @Override
@@ -125,7 +124,7 @@ public class ConcurrentMapApplicationErrorDao implements ApplicationErrorDao {
                 .filter(byStatus(ApplicationErrorStatus.UNRESOLVED))
                 .filter(error -> error.getHostName().equals(hostName))
                 .filter(error -> error.getDescription().equals(description))
-                .collect(toList());
+                .toList();
     }
 
     @Override
@@ -187,19 +186,11 @@ public class ConcurrentMapApplicationErrorDao implements ApplicationErrorDao {
     }
 
     private static Predicate<ApplicationError> byStatus(ApplicationErrorStatus status) {
-        switch (status) {
-            case ALL:
-                return applicationError -> true;
-
-            case RESOLVED:
-                return ApplicationError::isResolved;
-
-            case UNRESOLVED:
-                return not(ApplicationError::isResolved);
-
-            default:
-                throw new IllegalStateException("unknown status: " + status);
-        }
+        return switch (status) {
+            case ALL -> applicationError -> true;
+            case RESOLVED -> ApplicationError::isResolved;
+            case UNRESOLVED -> not(ApplicationError::isResolved);
+        };
     }
 
     @Override

--- a/src/main/java/org/kiwiproject/dropwizard/error/dao/jdk/NoOpApplicationErrorDao.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/dao/jdk/NoOpApplicationErrorDao.java
@@ -15,7 +15,7 @@ import java.util.Optional;
  * This might be useful in unit tests or when another class requires you to provide an {@link ApplicationErrorDao}
  * but you don't care about application errors and want them to be a "no-op" operation.
  * <p>
- * Methods that return primitive types return the default value, e.g.. zero for {@code long}, while methods that
+ * Methods that return primitive types return the default value, e.g. zero for {@code long}, while methods that
  * return reference types return a reasonable, non-null value, e.g. an empty list or optional.
  */
 public class NoOpApplicationErrorDao implements ApplicationErrorDao {

--- a/src/main/java/org/kiwiproject/dropwizard/error/health/TimeWindow.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/health/TimeWindow.java
@@ -2,11 +2,11 @@ package org.kiwiproject.dropwizard.error.health;
 
 import io.dropwizard.util.Duration;
 import io.dropwizard.validation.MinDuration;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
 import java.util.concurrent.TimeUnit;
 
 /**

--- a/src/main/java/org/kiwiproject/dropwizard/error/resource/ApplicationErrorResource.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/resource/ApplicationErrorResource.java
@@ -1,23 +1,23 @@
 package org.kiwiproject.dropwizard.error.resource;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
 import org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao;
 import org.kiwiproject.dropwizard.error.dao.ApplicationErrorStatus;
 import org.kiwiproject.dropwizard.error.model.ApplicationError;
 import org.kiwiproject.dropwizard.error.model.ApplicationErrorPage;
 import org.kiwiproject.jaxrs.KiwiStandardResponses;
 
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Response;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;

--- a/src/main/java/org/kiwiproject/dropwizard/error/resource/GotErrorsResource.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/resource/GotErrorsResource.java
@@ -1,13 +1,13 @@
 package org.kiwiproject.dropwizard.error.resource;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
 import org.kiwiproject.dropwizard.error.model.DataStoreType;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Response;
 import java.util.Map;
 
 /**

--- a/src/main/resources/dropwizard-app-errors-migrations.xml
+++ b/src/main/resources/dropwizard-app-errors-migrations.xml
@@ -2,7 +2,7 @@
 <!--
 Migrations file for Dropwizard Application Errors.
 
-We currently do not have an automated process for running this migration when not using the in-memory H2 database
+We currently do not have an automated process for running this migration when not using the in-memory H2 database,
 so you will need to copy the migration directly into your own application's migrations.xml file and run the migrations.
 The default Dropwizard migrations does support specifying separate files, but our current deployment process does not.
 

--- a/src/test/java/org/kiwiproject/dropwizard/error/ApplicationErrorThrowerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/ApplicationErrorThrowerTest.java
@@ -45,11 +45,13 @@ class ApplicationErrorThrowerTest {
 
         @Test
         void shouldThrow_WhenGivenNullErrorDao() {
+            //noinspection DataFlowIssue
             assertThrowsNullPointerException("errorDao", () -> new ApplicationErrorThrower(null, LOG));
         }
 
         @Test
         void shouldThrow_WhenGivenNullLogger() {
+            //noinspection DataFlowIssue
             assertThrowsNullPointerException("logger", () -> new ApplicationErrorThrower(errorDao, null));
         }
     }
@@ -59,12 +61,14 @@ class ApplicationErrorThrowerTest {
 
         @Test
         void shouldThrow_WhenGivenNullErrorDao() {
+            //noinspection DataFlowIssue
             assertThrowsNullPointerException("errorDao",
                     () -> ApplicationErrorThrower.builder().errorDao(null).logger(LOG).build());
         }
 
         @Test
         void shouldThrow_WhenGivenNullLogger() {
+            //noinspection DataFlowIssue
             assertThrowsNullPointerException("logger",
                     () -> ApplicationErrorThrower.builder().errorDao(errorDao).logger(null).build());
         }

--- a/src/test/java/org/kiwiproject/dropwizard/error/ErrorContextBuilderTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/ErrorContextBuilderTest.java
@@ -14,9 +14,9 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.lifecycle.setup.ScheduledExecutorServiceBuilder;
-import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;

--- a/src/test/java/org/kiwiproject/dropwizard/error/ErrorContextUtilitiesTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/ErrorContextUtilitiesTest.java
@@ -13,10 +13,10 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.codahale.metrics.health.HealthCheckRegistry;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.lifecycle.setup.ScheduledExecutorServiceBuilder;
-import io.dropwizard.setup.Environment;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -173,7 +173,7 @@ class ErrorContextUtilitiesTest {
             verifyNoMoreInteractions(healthChecks);
         }
 
-        @SuppressWarnings("ConstantConditions")
+        @SuppressWarnings("ConstantValue")
         @Test
         void shouldSkipRegisteringHealthCheck() {
             var healthCheck = ErrorContextUtilities.registerRecentErrorsHealthCheckOrNull(
@@ -217,7 +217,7 @@ class ErrorContextUtilitiesTest {
                     eq(TimeUnit.MINUTES));
         }
 
-        @SuppressWarnings("ConstantConditions")
+        @SuppressWarnings("ConstantValue")
         @Test
         void shouldSkipRegisteringHealthCheck() {
             var job = ErrorContextUtilities.registerCleanupJobOrNull(

--- a/src/test/java/org/kiwiproject/dropwizard/error/Jdbi3ErrorContextTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/Jdbi3ErrorContextTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/org/kiwiproject/dropwizard/error/SimpleErrorContextTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/SimpleErrorContextTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/org/kiwiproject/dropwizard/error/resource/ApplicationErrorResourceTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/resource/ApplicationErrorResourceTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.when;
 
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -26,8 +28,6 @@ import org.kiwiproject.dropwizard.error.model.ApplicationError.Resolved;
 import org.kiwiproject.dropwizard.error.model.ApplicationErrorPage;
 import org.kiwiproject.jaxrs.KiwiGenericTypes;
 
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/src/test/java/org/kiwiproject/dropwizard/error/test/mockito/ApplicationErrorVerificationsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/test/mockito/ApplicationErrorVerificationsTest.java
@@ -39,30 +39,25 @@ class ApplicationErrorVerificationsTest {
 
         void performSomeProcessingThatCanFail(String input) {
             switch (input) {
-                case "foo": // one error with exception
+                case "foo" -> { // one error with exception
                     var fooError = ApplicationError.newUnresolvedError("Processing failed for input: foo");
                     errorDao.insertOrIncrementCount(fooError);
                     logProcessingComplete(Level.WARN, input);
-                    break;
-
-                case "bar": // one error with exception
+                }
+                case "bar" -> { // one error with exception
                     var cause = new IOException("I/O error");
                     var ex = new UncheckedIOException(cause);
                     var barError = ApplicationError.newUnresolvedError("Processing threw error with cause for input: bar", ex);
                     errorDao.insertOrIncrementCount(barError);
                     logProcessingComplete(Level.WARN, input);
-                    break;
-
-                case "baz": // one error plus a second call on errorDao
+                }
+                case "baz" -> { // one error plus a second call on errorDao
                     var bazError = ApplicationError.newUnresolvedError("Processing failed for input: baz");
                     errorDao.insertOrIncrementCount(bazError);
                     errorDao.countAllErrors();
                     logProcessingComplete(Level.WARN, input);
-                    break;
-
-                default:
-                    logProcessingComplete(Level.INFO, input);
-                    break;
+                }
+                default -> logProcessingComplete(Level.INFO, input);
             }
         }
 


### PR DESCRIPTION
* Bump version to 2.0.0-SNAPSHOT
* Bump kiwi-parent from 2.0.20 to 3.0.1
* Bump kiwi-bom from 1.1.1 to 2.0.0
* Bump kiwi libraries to next major version
* Update build for JDK 17 and 20
* Update CodeQL workflow to use JDK 17
* Fix Dropwizard package changes
* Refactor from javax to jakarta namespace for Jakarta EE 9
* Minor JDK 17 sonar cleanup (use toList on Stream directly, enhanced switch)