### PR TITLE
New application error verification methods with custom VerificationMode

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/test/mockito/ApplicationErrorVerifications.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/test/mockito/ApplicationErrorVerifications.java
@@ -10,6 +10,7 @@ import lombok.experimental.UtilityClass;
 import org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao;
 import org.kiwiproject.dropwizard.error.model.ApplicationError;
 import org.mockito.ArgumentCaptor;
+import org.mockito.verification.VerificationMode;
 
 import java.util.List;
 
@@ -65,6 +66,57 @@ public class ApplicationErrorVerifications {
         var argumentCaptor = ArgumentCaptor.forClass(ApplicationError.class);
         verify(errorDao, atLeastOnce()).insertOrIncrementCount(argumentCaptor.capture());
         verifyNoMoreInteractions(errorDao);
+
+        return argumentCaptor.getAllValues();
+    }
+
+
+    /**
+     * {@link org.mockito.Mockito#verify(Object) Verify} that
+     * {@link ApplicationErrorDao#insertOrIncrementCount(ApplicationError)} was called using the given
+     * {@link VerificationMode} to verify the expected behavior, e.g. at least once, a specific number of
+     * times, within a timeout combined with a specific number of times, etc.
+     * <p>
+     * Returns the ApplicationError that was verified, or the latest one if multiple invocations occurred. It
+     * can be used to perform further inspection and/or assertions.
+     *
+     * @param errorDao a Mockito mock of {@link ApplicationErrorDao}
+     * @param mode     the {@link VerificationMode} to use when performing verification, e.g. {@code timeout(100).only()}
+     * @return the single {@link ApplicationError} argument, or the latest argument in the case of multiple
+     * invocations, assuming the verification passes
+     * @throws org.mockito.exceptions.base.MockitoAssertionError if verification fails. The exact type will be a
+     *                                                           subclass describing on the problem.
+     */
+    public static ApplicationError verifyOneOrLatestInsertOrIncrementCount(ApplicationErrorDao errorDao,
+                                                                           VerificationMode mode) {
+
+        var argumentCaptor = ArgumentCaptor.forClass(ApplicationError.class);
+        verify(errorDao, mode).insertOrIncrementCount(argumentCaptor.capture());
+
+        return argumentCaptor.getValue();
+    }
+
+    /**
+     * {@link org.mockito.Mockito#verify(Object) Verify} that
+     * {@link ApplicationErrorDao#insertOrIncrementCount(ApplicationError)} was called using the given
+     * {@link VerificationMode} to verify the expected behavior, e.g. at least once, a specific number of
+     * times, within a timeout combined with a specific number of times, etc.
+     * <p>
+     * Returns the list of ApplicationErrors that were verified, which can be used to perform further inspection and/or
+     * assertions. The order of the returned ApplicationError list is the order in which {@code insertOrIncrementCount}
+     * was called.
+     *
+     * @param errorDao a Mockito mock of {@link ApplicationErrorDao}
+     * @param mode     the {@link VerificationMode} to use when performing verification, e.g. {@code timeout(250).times(3)}
+     * @return all {@link ApplicationError} arguments assuming the verification passes
+     * @throws org.mockito.exceptions.base.MockitoAssertionError if verification fails. The exact type will be a
+     *                                                           subclass describing on the problem.
+     */
+    public static List<ApplicationError> verifyManyInsertOrIncrementCount(ApplicationErrorDao errorDao,
+                                                                          VerificationMode mode) {
+
+        var argumentCaptor = ArgumentCaptor.forClass(ApplicationError.class);
+        verify(errorDao, mode).insertOrIncrementCount(argumentCaptor.capture());
 
         return argumentCaptor.getAllValues();
     }


### PR DESCRIPTION
Add new methods verifyOneOrLatestInsertOrIncrementCount and verifyManyInsertOrIncrementCount to ApplicationErrorVerifications. These permit callers to specify a custom VerificationMode for more flexibility than the existing methods.

Closes #297