### PR TITLE
Refactor internals to replace large arg lists with "options" class

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/ErrorContextBuilder.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/ErrorContextBuilder.java
@@ -335,18 +335,7 @@ public class ErrorContextBuilder {
     }
 
     private Jdbi3ErrorContext newJdbi3ErrorContext(Jdbi jdbi) {
-        return new Jdbi3ErrorContext(
-                environment,
-                serviceDetails,
-                jdbi,
-                dataStoreType,
-                addErrorsResource,
-                addGotErrorsResource,
-                addHealthCheck,
-                timeWindowValue,
-                timeWindowUnit,
-                addCleanupJob,
-                cleanupConfig);
+        return new Jdbi3ErrorContext(environment, serviceDetails, jdbi, buildOptions());
     }
 
     /**
@@ -381,17 +370,19 @@ public class ErrorContextBuilder {
      * @return a new {@link ErrorContext} instance
      */
     public ErrorContext buildWithDao(ApplicationErrorDao errorDao) {
-        return new SimpleErrorContext(
-                environment,
-                serviceDetails,
-                errorDao,
-                dataStoreType,
-                addErrorsResource,
-                addGotErrorsResource,
-                addHealthCheck,
-                timeWindowValue,
-                timeWindowUnit,
-                addCleanupJob,
-                cleanupConfig);
+        return new SimpleErrorContext(environment, serviceDetails, errorDao, buildOptions());
+    }
+
+    private ErrorContextOptions buildOptions() {
+        return ErrorContextOptions.builder()
+                .dataStoreType(dataStoreType)
+                .addErrorsResource(addErrorsResource)
+                .addGotErrorsResource(addGotErrorsResource)
+                .addHealthCheck(addHealthCheck)
+                .timeWindowValue(timeWindowValue)
+                .timeWindowValue(timeWindowValue)
+                .addCleanupJob(addCleanupJob)
+                .cleanupConfig(cleanupConfig)
+                .build();
     }
 }

--- a/src/main/java/org/kiwiproject/dropwizard/error/ErrorContextOptions.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/ErrorContextOptions.java
@@ -1,0 +1,48 @@
+package org.kiwiproject.dropwizard.error;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+import org.kiwiproject.dropwizard.error.config.CleanupConfig;
+import org.kiwiproject.dropwizard.error.health.TimeWindow;
+import org.kiwiproject.dropwizard.error.model.DataStoreType;
+
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+
+/**
+ * Contains options common to different types of {@link ErrorContext}.
+ *
+ * @implNote This is not public and is subject to change.
+ */
+@Builder
+@Getter
+class ErrorContextOptions {
+
+    @NonNull
+    @Builder.Default
+    private DataStoreType dataStoreType = DataStoreType.SHARED;
+
+    @Builder.Default
+    private boolean addErrorsResource = true;
+
+    @Builder.Default
+    private boolean addGotErrorsResource = true;
+
+    @Builder.Default
+    private boolean addHealthCheck = true;
+
+    @Builder.Default
+    private long timeWindowValue = TimeWindow.DEFAULT_TIME_WINDOW_MINUTES;
+
+    @NonNull
+    @Builder.Default
+    private TemporalUnit timeWindowUnit = ChronoUnit.MINUTES;
+
+    @Builder.Default
+    private boolean addCleanupJob = true;
+
+    @Builder.Default
+    private CleanupConfig cleanupConfig = new CleanupConfig();
+}

--- a/src/test/java/org/kiwiproject/dropwizard/error/ErrorContextBuilderTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/ErrorContextBuilderTest.java
@@ -231,9 +231,7 @@ class ErrorContextBuilderTest {
             builder.buildWithConcurrentMapDao();
 
             var jersey = environment.jersey();
-            verify(jersey, never()).register(isA(ApplicationErrorResource.class));
-            verify(jersey, never()).register(isA(GotErrorsResource.class));
-            verifyNoMoreInteractions(jersey);
+            verifyNoInteractions(jersey);
         }
     }
 

--- a/src/test/java/org/kiwiproject/dropwizard/error/ErrorContextOptionsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/ErrorContextOptionsTest.java
@@ -1,0 +1,45 @@
+package org.kiwiproject.dropwizard.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.dropwizard.error.config.CleanupConfig;
+import org.kiwiproject.dropwizard.error.health.TimeWindow;
+import org.kiwiproject.dropwizard.error.model.DataStoreType;
+
+import java.time.temporal.ChronoUnit;
+
+@DisplayName("ErrorContextOptions")
+class ErrorContextOptionsTest {
+
+    @Test
+    void shouldBuildWithDefaultValues() {
+        var options = ErrorContextOptions.builder().build();
+
+        assertAll(
+            () -> assertThat(options.getDataStoreType()).isEqualTo(DataStoreType.SHARED),
+            () -> assertThat(options.isAddErrorsResource()).isTrue(),
+            () -> assertThat(options.isAddGotErrorsResource()).isTrue(),
+            () -> assertThat(options.isAddHealthCheck()).isTrue(),
+            () -> assertThat(options.getTimeWindowValue()).isEqualTo(TimeWindow.DEFAULT_TIME_WINDOW_MINUTES),
+            () -> assertThat(options.getTimeWindowUnit()).isEqualTo(ChronoUnit.MINUTES),
+            () -> assertThat(options.isAddCleanupJob()).isTrue(),
+            () -> assertThat(options.getCleanupConfig()).usingRecursiveComparison().isEqualTo(new CleanupConfig())
+        );
+    }
+
+    @Test
+    void shouldRequireDataStoreType() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> ErrorContextOptions.builder().dataStoreType(null).build());
+    }
+
+    @Test
+    void shouldRequireTimeWindowUnit() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> ErrorContextOptions.builder().timeWindowUnit(null).build());
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/error/Jdbi3ErrorContextTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/Jdbi3ErrorContextTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.kiwiproject.dropwizard.error.config.CleanupConfig;
 import org.kiwiproject.dropwizard.error.dao.jdbi3.Jdbi3ApplicationErrorDao;
 import org.kiwiproject.dropwizard.error.health.RecentErrorsHealthCheck;
 import org.kiwiproject.dropwizard.error.model.ApplicationError;
@@ -54,8 +53,8 @@ class Jdbi3ErrorContextTest {
 
         jdbi = Jdbi.create(database.getDataSource()).installPlugin(new SqlObjectPlugin());
 
-        timeWindowAmount = 20;
-        timeWindowUnit = ChronoUnit.MINUTES;
+        timeWindowAmount = 1;
+        timeWindowUnit = ChronoUnit.HOURS;
     }
 
     @AfterEach
@@ -138,18 +137,15 @@ class Jdbi3ErrorContextTest {
         }
 
         private Jdbi3ErrorContext newContextWithHealthCheck(boolean addHealthCheck) {
-            return new Jdbi3ErrorContext(environment,
-                    serviceDetails,
-                    jdbi,
-                    DataStoreType.NOT_SHARED,
-                    true,
-                    true,
-                    addHealthCheck,
-                    timeWindowAmount,
-                    timeWindowUnit,
-                    false,
-                    new CleanupConfig()
-                    );
+            var options = ErrorContextOptions.builder()
+                    .dataStoreType(DataStoreType.NOT_SHARED)
+                    .addHealthCheck(addHealthCheck)
+                    .timeWindowValue(timeWindowAmount)
+                    .timeWindowUnit(timeWindowUnit)
+                    .addCleanupJob(false)
+                    .build();
+
+            return new Jdbi3ErrorContext(environment, serviceDetails, jdbi, options);
         }
     }
 
@@ -178,17 +174,17 @@ class Jdbi3ErrorContextTest {
 
         private Jdbi3ErrorContext newContextWithAddResourceOptionsOf(boolean addErrorsResource,
                                                                      boolean addGotErrorsResource) {
-            return new Jdbi3ErrorContext(environment,
-                    serviceDetails,
-                    jdbi,
-                    DataStoreType.NOT_SHARED,
-                    addErrorsResource,
-                    addGotErrorsResource,
-                    true,
-                    timeWindowAmount,
-                    timeWindowUnit,
-                    false,
-                    new CleanupConfig());
+
+            var options = ErrorContextOptions.builder()
+                    .dataStoreType(DataStoreType.NOT_SHARED)
+                    .addErrorsResource(addErrorsResource)
+                    .addGotErrorsResource(addGotErrorsResource)
+                    .timeWindowValue(timeWindowAmount)
+                    .timeWindowUnit(timeWindowUnit)
+                    .addCleanupJob(false)
+                    .build();
+
+            return new Jdbi3ErrorContext(environment, serviceDetails, jdbi, options);
         }
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/error/SimpleErrorContextTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/SimpleErrorContextTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.kiwiproject.dropwizard.error.config.CleanupConfig;
 import org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao;
 import org.kiwiproject.dropwizard.error.dao.jdk.NoOpApplicationErrorDao;
 import org.kiwiproject.dropwizard.error.health.RecentErrorsHealthCheck;
@@ -114,18 +113,14 @@ class SimpleErrorContextTest {
     }
 
     private SimpleErrorContext newContextWithAddHealthCheckOf(boolean addHealthCheck) {
-        return new SimpleErrorContext(environment,
-                serviceDetails,
-                errorDao,
-                dataStoreType,
-                true,
-                true,
-                addHealthCheck,
-                timeWindowAmount,
-                timeWindowUnit,
-                false,
-                new CleanupConfig()
-        );
+        var options = ErrorContextOptions.builder()
+            .dataStoreType(dataStoreType)
+            .addHealthCheck(addHealthCheck)
+            .timeWindowValue(timeWindowAmount)
+            .addCleanupJob(false)
+            .build();
+
+        return new SimpleErrorContext(environment, serviceDetails, errorDao, options);
     }
 
     @Nested
@@ -154,16 +149,16 @@ class SimpleErrorContextTest {
 
     private SimpleErrorContext newContextWithAddResourceOptionsOf(boolean addErrorsResource,
                                                                   boolean addGotErrorsResource) {
-        return new SimpleErrorContext(environment,
-                serviceDetails,
-                errorDao,
-                dataStoreType,
-                addErrorsResource,
-                addGotErrorsResource,
-                true,
-                timeWindowAmount,
-                timeWindowUnit,
-                false,
-                new CleanupConfig());
+
+        var options = ErrorContextOptions.builder()
+                .dataStoreType(dataStoreType)
+                .addErrorsResource(addErrorsResource)
+                .addGotErrorsResource(addGotErrorsResource)
+                .timeWindowValue(timeWindowAmount)
+                .timeWindowUnit(timeWindowUnit)
+                .addCleanupJob(false)
+                .build();
+
+        return new SimpleErrorContext(environment, serviceDetails, errorDao, options);
     }
 }


### PR DESCRIPTION
Note specifically that NO public APIs are affected.

* Introduce ErrorContextOptions class
* Refactor code to use the options class instead of large argument lists
* Add Checker Nullable annotation to methods in ErrorContextUtilities

Closes #300