### PR TITLE
Only force embedded H2 databases to be NOT_SHARED

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbc.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbc.java
@@ -1,6 +1,8 @@
 package org.kiwiproject.dropwizard.error.dao;
 
 import static java.util.Objects.isNull;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.startsWithAny;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiStrings.format;
 
@@ -16,11 +18,13 @@ import liquibase.exception.CommandExecutionException;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.kiwiproject.dropwizard.error.model.DataStoreType;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Locale;
 
 /**
  * Helper utilities when using JDBC for application error persistence.
@@ -34,9 +38,22 @@ public class ApplicationErrorJdbc {
     private static final String MIGRATIONS_FILENAME = "dropwizard-app-errors-migrations.xml";
     private static final String H2_DRIVER = "org.h2.Driver";
     private static final String H2_IN_MEMORY_DB_URL = "jdbc:h2:mem:dw-app-errors;DB_CLOSE_DELAY=-1";
-
     private static final String H2_IN_MEMORY_DB_USERNAME = "appErrorUser";
     private static final String H2_IN_MEMORY_DB_PASSWORD = RandomStringUtils.randomAlphanumeric(20);
+
+    private static final String H2_EMBEDDED_IN_MEMORY_URL_PREFIX = "jdbc:h2:mem:";
+    private static final String H2_EMBEDDED_FILE_EXPLICIT_URL_PREFIX = "jdbc:h2:file:";
+    private static final String H2_EMBEDDED_FILE_RELATIVE_URL_PREFIX = "jdbc:h2:~/";
+    private static final String H2_EMBEDDED_FILE_POSIX_ABSOLUTE_URL_PREFIX = "jdbc:h2:/";
+    private static final String H2_EMBEDDED_FILE_WINDOWS_ABSOLUTE_URL_PREFIX = "jdbc:h2:C:";
+    private static final String[] H2_EMBEDDED_URL_PREFIXES = {
+        H2_EMBEDDED_IN_MEMORY_URL_PREFIX,
+        H2_EMBEDDED_FILE_EXPLICIT_URL_PREFIX,
+        H2_EMBEDDED_FILE_RELATIVE_URL_PREFIX,
+        H2_EMBEDDED_FILE_POSIX_ABSOLUTE_URL_PREFIX,
+        H2_EMBEDDED_FILE_WINDOWS_ABSOLUTE_URL_PREFIX
+    };
+    private static final String H2_AUTOMATIC_MIXED_MODE = "AUTO_SERVER=TRUE";
 
     /**
      * Creates an in-memory H2 database that will stay alive as long as the JVM is alive and will use the same database
@@ -113,14 +130,12 @@ public class ApplicationErrorJdbc {
      *
      * @param dataSourceFactory the DataSourceFactory to check
      * @return the resolved DataStoreType
-     * @implNote Currently this uses ONLY the driver class to make this determination and always assumes H2 databases
-     * are NOT shared. This simplistic implementation could change in the future.
-     * @see #isH2DataStore(DataSourceFactory)
+     * @see #isH2EmbeddedDataStore(DataSourceFactory)
      */
     public static DataStoreType dataStoreTypeOf(DataSourceFactory dataSourceFactory) {
         checkArgumentNotNull(dataSourceFactory);
 
-        if (isH2DataStore(dataSourceFactory)) {
+        if (isH2EmbeddedDataStore(dataSourceFactory)) {
             return DataStoreType.NOT_SHARED;
         }
 
@@ -132,15 +147,40 @@ public class ApplicationErrorJdbc {
      *
      * @param dataSourceFactory the DataSourceFactory to check
      * @return true if the driver class is the H2 driver, false otherwise (including null argument)
-     * @implNote Currently this uses ONLY the driver class to make this determination and always assumes H2 databases
-     * are NOT shared. This simplistic implementation could change in the future.
      */
-    public static boolean isH2DataStore(DataSourceFactory dataSourceFactory) {
+    public static boolean isH2DataStore(@Nullable DataSourceFactory dataSourceFactory) {
         if (isNull(dataSourceFactory)) {
             return false;
         }
 
         return H2_DRIVER.equals(dataSourceFactory.getDriverClass());
+    }
+
+    /**
+     *  Is the given {@link DataSourceFactory} configured for an embedded (in-memory or file-based) H2 database?
+     *
+     * @param dataSourceFactory the DataSourceFactory to check
+     * @return true if the driver class is the H2 driver, and the databae URL is definitely an embedded in-memory
+     * or file-based database connection string. If the driver is not H2, or the URL is not definitively known
+     * to be for an embedded database, returns false.
+     * @see <a href="http://www.h2database.com/html/features.html#connection_modes">H2 Connection Modes</a>
+     * @see <a href="http://www.h2database.com/html/features.html#database_url">H2 Database URL Overview</a>
+     * @see <a href="http://www.h2database.com/html/features.html#auto_mixed_mode">H2 Automatic Mixed Mode</a>
+     */
+    public static boolean isH2EmbeddedDataStore(@Nullable DataSourceFactory dataSourceFactory) {
+        if (!isH2DataStore(dataSourceFactory)) {
+            return false;
+        }
+
+        var url = dataSourceFactory.getUrl();
+
+        return isNotBlank(url) &&
+                startsWithAny(url, H2_EMBEDDED_URL_PREFIXES) &&
+                isNotH2AutomaticMixedMode(url);
+    }
+
+    private static boolean isNotH2AutomaticMixedMode(String url) {
+        return !url.toUpperCase(Locale.US).contains(H2_AUTOMATIC_MIXED_MODE);
     }
 
     /**

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbcTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbcTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.dropwizard.error.model.DataStoreType;
 import org.kiwiproject.test.jdbc.RuntimeSQLException;
@@ -108,10 +109,32 @@ class ApplicationErrorJdbcTest {
     @Nested
     class DataStoreTypeOf {
 
-        @Test
-        void shouldReturn_NOT_SHARED_WhenH2Driver() {
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "jdbc:h2:mem:",
+            "jdbc:h2:mem:test_db",
+            "jdbc:h2:~/test",
+            "jdbc:h2:file:/data/sample",
+            "jdbc:h2:file:C:/data/sample.db",
+        })
+        void shouldReturn_NOT_SHARED_WhenH2Driver_AndEmbeddedConnectionUrl(String url) {
             dataSourceFactory.setDriverClass(org.h2.Driver.class.getName());
+            dataSourceFactory.setUrl(url);
             assertThat(ApplicationErrorJdbc.dataStoreTypeOf(dataSourceFactory)).isEqualTo(DataStoreType.NOT_SHARED);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "jdbc:h2:tcp://localhost/~/test",
+            "jdbc:h2:tcp://dbserv:8084/~/sample",
+            "jdbc:h2:ssl://localhost:8085/~/sample",
+            "jdbc:h2:zip:~/db.zip!/test",
+            "jdbc:h2:/data/test;AUTO_SERVER=TRUE",  // mixed mode
+        })
+        void shouldReturn_SHARED_WhenH2Driver_AndServerOrMixedModeConnectionUrl(String url) {
+            dataSourceFactory.setDriverClass(org.h2.Driver.class.getName());
+            dataSourceFactory.setUrl(url);
+            assertThat(ApplicationErrorJdbc.dataStoreTypeOf(dataSourceFactory)).isEqualTo(DataStoreType.SHARED);
         }
 
         @Test
@@ -184,6 +207,65 @@ class ApplicationErrorJdbcTest {
             var dataSourceFactory = new DataSourceFactory();
             dataSourceFactory.setDriverClass(Driver.class.getName());
             assertThat(ApplicationErrorJdbc.isH2DataStore(dataSourceFactory)).isTrue();
+        }
+    }
+
+    @Nested
+    class IsH2EmbeddedDataStore {
+
+        @Test
+        void shouldReturnFalse_WhenGivenNullDataSourceFactory() {
+            assertThat(ApplicationErrorJdbc.isH2EmbeddedDataStore(null)).isFalse();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "org.postgresql.Driver",
+                "com.mysql.jdbc.Driver",
+                "org.acme.db.Driver"
+        })
+        void shouldReturnFalse_WhenGivenNonH2DataSourceFactory(String value) {
+            var dataSourceFactory = new DataSourceFactory();
+            dataSourceFactory.setDriverClass(value);
+            assertThat(ApplicationErrorJdbc.isH2EmbeddedDataStore(dataSourceFactory)).isFalse();
+        }
+
+        /**
+         * We do NOT consider the "Automatic mixed mode" to be embedded, since it
+         * allows connections from other processes, JVMs, etc. This mode is enabled
+         * via the AUTO_SERVER=TRUE
+         */
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+            jdbc:h2:mem:, true
+            jdbc:h2:mem:test_db, true
+            jdbc:h2:~/test, true
+            jdbc:h2:~/test.db, true
+            jdbc:h2:file:/data/sample, true
+            jdbc:h2:file:/data/var/h2/test.db, true
+            jdbc:h2:file:C:/data/sample.db, true
+            jdbc:h2:file:~/secure;CIPHER=AES, true
+            jdbc:h2:file:~/private;CIPHER=AES;FILE_LOCK=SOCKET, true
+            jdbc:h2:file:~/sample;IFEXISTS=TRUE, true
+            jdbc:h2:file:~/sample;USER=sa;PASSWORD=123, true
+            jdbc:h2:~/test;MODE=MYSQL;DATABASE_TO_LOWER=TRUE, true
+
+            jdbc:h2:tcp://localhost/~/test, false
+            jdbc:h2:tcp://dbserv:8084/~/sample, false
+            jdbc:h2:tcp://localhost/mem:test, false
+            jdbc:h2:tcp://localhost/~/test;AUTO_RECONNECT=TRUE, false
+            jdbc:h2:ssl://localhost:8085/~/sample, false
+            jdbc:h2:ssl://localhost/~/test;CIPHER=AES, false
+            jdbc:h2:zip:~/db.zip!/test, false
+            jdbc:h2:/data/test;AUTO_SERVER=TRUE, false
+            jdbc:h2:/data/test;AUTO_SERVER=true, false
+            jdbc:h2:/data/test;auto_server=true, false
+            """)
+        void shouldReturnTrue_WhenGivenEmbeddedH2DataSourceFactory(String url, boolean isEmbeddedUrl) {
+            var dataSourceFactory = new DataSourceFactory();
+            dataSourceFactory.setDriverClass(Driver.class.getName());
+            dataSourceFactory.setUrl(url);
+            assertThat(ApplicationErrorJdbc.isH2EmbeddedDataStore(dataSourceFactory)).isEqualTo(isEmbeddedUrl);
         }
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbcTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbcTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.dropwizard.error.model.DataStoreType;
 import org.kiwiproject.test.jdbc.RuntimeSQLException;
@@ -23,7 +24,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 
 @DisplayName("ApplicationErrorJdbc")
-@SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
+@SuppressWarnings({ "SqlDialectInspection", "SqlNoDataSourceInspection" })
 class ApplicationErrorJdbcTest {
 
     private DataSourceFactory dataSourceFactory;
@@ -111,11 +112,11 @@ class ApplicationErrorJdbcTest {
 
         @ParameterizedTest
         @ValueSource(strings = {
-            "jdbc:h2:mem:",
-            "jdbc:h2:mem:test_db",
-            "jdbc:h2:~/test",
-            "jdbc:h2:file:/data/sample",
-            "jdbc:h2:file:C:/data/sample.db",
+                "jdbc:h2:mem:",
+                "jdbc:h2:mem:test_db",
+                "jdbc:h2:~/test",
+                "jdbc:h2:file:/data/sample",
+                "jdbc:h2:file:C:/data/sample.db",
         })
         void shouldReturn_NOT_SHARED_WhenH2Driver_AndEmbeddedConnectionUrl(String url) {
             dataSourceFactory.setDriverClass(org.h2.Driver.class.getName());
@@ -125,11 +126,11 @@ class ApplicationErrorJdbcTest {
 
         @ParameterizedTest
         @ValueSource(strings = {
-            "jdbc:h2:tcp://localhost/~/test",
-            "jdbc:h2:tcp://dbserv:8084/~/sample",
-            "jdbc:h2:ssl://localhost:8085/~/sample",
-            "jdbc:h2:zip:~/db.zip!/test",
-            "jdbc:h2:/data/test;AUTO_SERVER=TRUE",  // mixed mode
+                "jdbc:h2:tcp://localhost/~/test",
+                "jdbc:h2:tcp://dbserv:8084/~/sample",
+                "jdbc:h2:ssl://localhost:8085/~/sample",
+                "jdbc:h2:zip:~/db.zip!/test",
+                "jdbc:h2:/data/test;AUTO_SERVER=TRUE",  // mixed mode
         })
         void shouldReturn_SHARED_WhenH2Driver_AndServerOrMixedModeConnectionUrl(String url) {
             dataSourceFactory.setDriverClass(org.h2.Driver.class.getName());
@@ -174,6 +175,7 @@ class ApplicationErrorJdbcTest {
 
         @Test
         void shouldThrow_WhenMigrationErrorOccurs() {
+            //noinspection resource
             var conn = mock(Connection.class);
 
             assertThatThrownBy(() -> ApplicationErrorJdbc.migrateDatabase(conn))
@@ -191,6 +193,20 @@ class ApplicationErrorJdbcTest {
         }
 
         @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {
+                "jdbc:mysql://localhost:3306/test_db",
+                "jdbc:postgresql://localhost:5432/sample",
+                "jdbc:sqlite:sample.db"
+        })
+        void shouldReturnFalse_WhenDriverIsH2_ButUrlIsNotH2(String jdbcUrl) {
+            var dataSourceFactory = new DataSourceFactory();
+            dataSourceFactory.setDriverClass(Driver.class.getName());
+            dataSourceFactory.setUrl(jdbcUrl);
+            assertThat(ApplicationErrorJdbc.isH2DataStore(dataSourceFactory)).isFalse();
+        }
+
+        @ParameterizedTest
         @ValueSource(strings = {
                 "org.postgresql.Driver",
                 "com.mysql.jdbc.Driver",
@@ -202,10 +218,16 @@ class ApplicationErrorJdbcTest {
             assertThat(ApplicationErrorJdbc.isH2DataStore(dataSourceFactory)).isFalse();
         }
 
-        @Test
-        void shouldReturnTrue_WhenGivenH2DataSourceFactory() {
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "jdbc:h2:mem:",
+                "jdbc:h2:file:/data/sample",
+                "jdbc:h2:tcp://localhost/~/test"
+        })
+        void shouldReturnTrue_WhenGivenH2DataSourceFactory(String jdbcUrl) {
             var dataSourceFactory = new DataSourceFactory();
             dataSourceFactory.setDriverClass(Driver.class.getName());
+            dataSourceFactory.setUrl(jdbcUrl);
             assertThat(ApplicationErrorJdbc.isH2DataStore(dataSourceFactory)).isTrue();
         }
     }
@@ -216,6 +238,22 @@ class ApplicationErrorJdbcTest {
         @Test
         void shouldReturnFalse_WhenGivenNullDataSourceFactory() {
             assertThat(ApplicationErrorJdbc.isH2EmbeddedDataStore(null)).isFalse();
+        }
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+                org.h2.Driver, jdbc:sqlite:sample.db
+                org.acme.db.Driver, jdbc:h2:~/test_db
+                '', jdbc:h2:~/test_db
+                null, jdbc:h2:~/test_db
+                org.h2.Driver, ''
+                org.h2.Driver, null
+                """, nullValues = "null")
+        void shouldReturnFalse_WhenGivenNonH2_DataSourceFactory(String driverClass, String jdbcUrl) {
+            var dataSourceFactory = new DataSourceFactory();
+            dataSourceFactory.setDriverClass(driverClass);
+            dataSourceFactory.setUrl(jdbcUrl);
+            assertThat(ApplicationErrorJdbc.isH2EmbeddedDataStore(dataSourceFactory)).isFalse();
         }
 
         @ParameterizedTest
@@ -237,30 +275,30 @@ class ApplicationErrorJdbcTest {
          */
         @ParameterizedTest
         @CsvSource(textBlock = """
-            jdbc:h2:mem:, true
-            jdbc:h2:mem:test_db, true
-            jdbc:h2:~/test, true
-            jdbc:h2:~/test.db, true
-            jdbc:h2:file:/data/sample, true
-            jdbc:h2:file:/data/var/h2/test.db, true
-            jdbc:h2:file:C:/data/sample.db, true
-            jdbc:h2:file:~/secure;CIPHER=AES, true
-            jdbc:h2:file:~/private;CIPHER=AES;FILE_LOCK=SOCKET, true
-            jdbc:h2:file:~/sample;IFEXISTS=TRUE, true
-            jdbc:h2:file:~/sample;USER=sa;PASSWORD=123, true
-            jdbc:h2:~/test;MODE=MYSQL;DATABASE_TO_LOWER=TRUE, true
+                jdbc:h2:mem:, true
+                jdbc:h2:mem:test_db, true
+                jdbc:h2:~/test, true
+                jdbc:h2:~/test.db, true
+                jdbc:h2:file:/data/sample, true
+                jdbc:h2:file:/data/var/h2/test.db, true
+                jdbc:h2:file:C:/data/sample.db, true
+                jdbc:h2:file:~/secure;CIPHER=AES, true
+                jdbc:h2:file:~/private;CIPHER=AES;FILE_LOCK=SOCKET, true
+                jdbc:h2:file:~/sample;IFEXISTS=TRUE, true
+                jdbc:h2:file:~/sample;USER=sa;PASSWORD=123, true
+                jdbc:h2:~/test;MODE=MYSQL;DATABASE_TO_LOWER=TRUE, true
 
-            jdbc:h2:tcp://localhost/~/test, false
-            jdbc:h2:tcp://dbserv:8084/~/sample, false
-            jdbc:h2:tcp://localhost/mem:test, false
-            jdbc:h2:tcp://localhost/~/test;AUTO_RECONNECT=TRUE, false
-            jdbc:h2:ssl://localhost:8085/~/sample, false
-            jdbc:h2:ssl://localhost/~/test;CIPHER=AES, false
-            jdbc:h2:zip:~/db.zip!/test, false
-            jdbc:h2:/data/test;AUTO_SERVER=TRUE, false
-            jdbc:h2:/data/test;AUTO_SERVER=true, false
-            jdbc:h2:/data/test;auto_server=true, false
-            """)
+                jdbc:h2:tcp://localhost/~/test, false
+                jdbc:h2:tcp://dbserv:8084/~/sample, false
+                jdbc:h2:tcp://localhost/mem:test, false
+                jdbc:h2:tcp://localhost/~/test;AUTO_RECONNECT=TRUE, false
+                jdbc:h2:ssl://localhost:8085/~/sample, false
+                jdbc:h2:ssl://localhost/~/test;CIPHER=AES, false
+                jdbc:h2:zip:~/db.zip!/test, false
+                jdbc:h2:/data/test;AUTO_SERVER=TRUE, false
+                jdbc:h2:/data/test;AUTO_SERVER=true, false
+                jdbc:h2:/data/test;auto_server=true, false
+                """)
         void shouldReturnTrue_WhenGivenEmbeddedH2DataSourceFactory(String url, boolean isEmbeddedUrl) {
             var dataSourceFactory = new DataSourceFactory();
             dataSourceFactory.setDriverClass(Driver.class.getName());


### PR DESCRIPTION
* Add isH2EmbeddedDataStore to ApplicationErrorJdbc
* Remove the erroneous implNote from isH2DataStore in ApplicationErrorJdbc; the method name tells you exactly wha it does
* Change ErrorContextBuilder to force NOT_SHARED only when the data store type has already been set, and the JDBC URL in the DataSourceFactory is an H2 URL that is for an embedded connection.

Closes  #306