### PR TITLE
Add plain JDBC ApplicationErrorDao implementation

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbc.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbc.java
@@ -220,13 +220,6 @@ public class ApplicationErrorJdbc {
         checkState(rs.next(), "ResultSet.next() returned false");
     }
 
-    @SuppressWarnings({ "SqlDialectInspection", "SqlNoDataSourceInspection" })
-    public static void shutdownH2Database(JdbcDataSource h2DataSource) throws SQLException {
-        try (var conn = h2DataSource.getConnection(); var stmt = conn.createStatement()) {
-            stmt.executeUpdate("shutdown");
-        }
-    }
-
     /**
      * Runtime exception wrapper around JDBC-related exceptions, e.g. {@link SQLException}.
      */

--- a/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbc.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbc.java
@@ -1,11 +1,13 @@
 package org.kiwiproject.dropwizard.error.dao;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.isNull;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.startsWithAny;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiStrings.format;
+import static org.kiwiproject.jdbc.KiwiJdbc.utcZonedDateTimeFromTimestamp;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.db.DataSourceFactory;
@@ -20,10 +22,13 @@ import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.h2.jdbcx.JdbcDataSource;
+import org.kiwiproject.dropwizard.error.model.ApplicationError;
 import org.kiwiproject.dropwizard.error.model.DataStoreType;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Locale;
 
@@ -192,10 +197,44 @@ public class ApplicationErrorJdbc {
         return !url.toUpperCase(Locale.US).contains(H2_AUTOMATIC_MIXED_MODE);
     }
 
+    public static ApplicationError mapFrom(ResultSet rs) throws SQLException {
+        return ApplicationError.builder()
+                .id(rs.getLong("id"))
+                .createdAt(utcZonedDateTimeFromTimestamp(rs, "created_at"))
+                .updatedAt(utcZonedDateTimeFromTimestamp(rs, "updated_at"))
+                .numTimesOccurred(rs.getInt("num_times_occurred"))
+                .description(rs.getString("description"))
+                .exceptionType(rs.getString("exception_type"))
+                .exceptionMessage(rs.getString("exception_message"))
+                .exceptionCauseType(rs.getString("exception_cause_type"))
+                .exceptionCauseMessage(rs.getString("exception_cause_message"))
+                .stackTrace(rs.getString("stack_trace"))
+                .resolved(rs.getBoolean("resolved"))
+                .hostName(rs.getString("host_name"))
+                .ipAddress(rs.getString("ip_address"))
+                .port(rs.getInt("port"))
+                .build();
+    }
+
+    public static void nextOrThrow(ResultSet rs) throws SQLException {
+        checkState(rs.next(), "ResultSet.next() returned false");
+    }
+
+    @SuppressWarnings({ "SqlDialectInspection", "SqlNoDataSourceInspection" })
+    public static void shutdownH2Database(JdbcDataSource h2DataSource) throws SQLException {
+        try (var conn = h2DataSource.getConnection(); var stmt = conn.createStatement()) {
+            stmt.executeUpdate("shutdown");
+        }
+    }
+
     /**
      * Runtime exception wrapper around JDBC-related exceptions, e.g. {@link SQLException}.
      */
     public static class ApplicationErrorJdbcException extends RuntimeException {
+        public ApplicationErrorJdbcException(Throwable cause) {
+            super(cause);
+        }
+
         ApplicationErrorJdbcException(String message, Throwable cause) {
             super(message, cause);
         }

--- a/src/main/java/org/kiwiproject/dropwizard/error/dao/jdbi3/Jdbi3ApplicationErrorRowMapper.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/dao/jdbi3/Jdbi3ApplicationErrorRowMapper.java
@@ -1,10 +1,8 @@
 package org.kiwiproject.dropwizard.error.dao.jdbi3;
 
-import static org.kiwiproject.jdbc.KiwiJdbc.intValueOrNull;
-import static org.kiwiproject.jdbc.KiwiJdbc.utcZonedDateTimeFromTimestamp;
-
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc;
 import org.kiwiproject.dropwizard.error.model.ApplicationError;
 
 import java.sql.ResultSet;
@@ -17,21 +15,6 @@ public class Jdbi3ApplicationErrorRowMapper implements RowMapper<ApplicationErro
 
     @Override
     public ApplicationError map(ResultSet rs, StatementContext ctx) throws SQLException {
-        return ApplicationError.builder()
-                .id(rs.getLong("id"))
-                .createdAt(utcZonedDateTimeFromTimestamp(rs, "created_at"))
-                .updatedAt(utcZonedDateTimeFromTimestamp(rs, "updated_at"))
-                .numTimesOccurred(rs.getInt("num_times_occurred"))
-                .description(rs.getString("description"))
-                .exceptionType(rs.getString("exception_type"))
-                .exceptionMessage(rs.getString("exception_message"))
-                .exceptionCauseType(rs.getString("exception_cause_type"))
-                .exceptionCauseMessage(rs.getString("exception_cause_message"))
-                .stackTrace(rs.getString("stack_trace"))
-                .resolved(rs.getBoolean("resolved"))
-                .hostName(rs.getString("host_name"))
-                .ipAddress(rs.getString("ip_address"))
-                .port(intValueOrNull(rs, "port"))
-                .build();
+        return ApplicationErrorJdbc.mapFrom(rs);         
     }
 }

--- a/src/main/java/org/kiwiproject/dropwizard/error/dao/jdk/JdbcApplicationErrorDao.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/dao/jdk/JdbcApplicationErrorDao.java
@@ -1,0 +1,322 @@
+package org.kiwiproject.dropwizard.error.dao.jdk;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentIsNull;
+import static org.kiwiproject.base.KiwiStrings.f;
+import static org.kiwiproject.collect.KiwiLists.first;
+import static org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao.checkPagingArgumentsAndCalculateZeroBasedOffset;
+import static org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc.nextOrThrow;
+import static org.kiwiproject.jdbc.KiwiJdbc.timestampFromZonedDateTime;
+
+import org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao;
+import org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc;
+import org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc.ApplicationErrorJdbcException;
+import org.kiwiproject.dropwizard.error.dao.ApplicationErrorStatus;
+import org.kiwiproject.dropwizard.error.model.ApplicationError;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Implementation of {@link ApplicationErrorDao} that uses plain JDBC, and therefore does not require
+ * any additional dependencies outside the JDK. It might be useful when an application is using a
+ * relational database but something other than JDBI, for example Hibernate or another ORM or ORM-like
+ * framework such as jOOQ.
+ */
+@SuppressWarnings({ "SqlDialectInspection", "SqlNoDataSourceInspection" })
+public class JdbcApplicationErrorDao implements ApplicationErrorDao {
+
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private final DataSource dataSource;
+
+    public JdbcApplicationErrorDao(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public Optional<ApplicationError> getById(long id) {
+        try (var conn = connection();
+             var ps = conn.prepareStatement("select * from application_errors where id = ?")) {
+
+            ps.setLong(1, id);
+
+            try (var resultSet = ps.executeQuery()) {
+                if (resultSet.next()) {
+                    var applicationError = ApplicationErrorJdbc.mapFrom(resultSet);
+                    return Optional.of(applicationError);
+                }
+                return Optional.empty();
+            }
+        } catch (SQLException e) {
+            throw new ApplicationErrorJdbcException(e);
+        }
+    }
+
+    @Override
+    public long countResolvedErrors() {
+        return countUsingQuery("select count(id) from application_errors where resolved = true");
+    }
+
+    @Override
+    public long countUnresolvedErrors() {
+        return countUsingQuery("select count(id) from application_errors where resolved = false");
+    }
+
+    @Override
+    public long countAllErrors() {
+        return countUsingQuery("select count(id) from application_errors");
+    }
+
+    private long countUsingQuery(String sql) {
+        try (var conn = connection(); var stmt = conn.createStatement(); var rs = stmt.executeQuery(sql)) {
+            nextOrThrow(rs);
+            return rs.getLong(1);
+        } catch (SQLException e) {
+            throw new ApplicationErrorJdbcException(e);
+        }
+    }
+
+    @Override
+    public long countUnresolvedErrorsSince(ZonedDateTime since) {
+        try (var conn = connection();
+             var ps = conn.prepareStatement("select count(id) from application_errors where resolved = false and updated_at >= ?")) {
+
+            ps.setTimestamp(1, timestampFromZonedDateTime(since));
+
+            try (var rs = ps.executeQuery()) {
+                nextOrThrow(rs);
+                return rs.getLong(1);
+            }
+        } catch (SQLException e) {
+            throw new ApplicationErrorJdbcException(e);
+        }
+    }
+
+    @Override
+    public long countUnresolvedErrorsOnHostSince(ZonedDateTime since, String hostName, String ipAddress) {
+        try (var conn = connection();
+             var ps = conn.prepareStatement("select count(id) from application_errors" +
+                     " where resolved = false and updated_at >= ? and host_name = ? and ip_address = ?")) {
+
+            ps.setTimestamp(1, timestampFromZonedDateTime(since));
+            ps.setString(2, hostName);
+            ps.setString(3, ipAddress);
+
+            try (var rs = ps.executeQuery()) {
+                nextOrThrow(rs);
+                return rs.getLong(1);
+            }
+        } catch (SQLException e) {
+            throw new ApplicationErrorJdbcException(e);
+        }
+    }
+
+    @Override
+    public List<ApplicationError> getAllErrors(int pageNumber, int pageSize) {
+        int offset = checkPagingArgumentsAndCalculateZeroBasedOffset(pageNumber, pageSize);
+        var sql = "select * from application_errors order by updated_at desc" +
+                paginationClause(pageSize, offset);
+
+        try (var conn = connection(); var stmt = conn.createStatement(); var rs = stmt.executeQuery(sql)) {
+            return collectErrors(rs, pageSize);
+        } catch (SQLException e) {
+            throw new ApplicationErrorJdbcException(e);
+        }
+    }
+
+    @Override
+    public List<ApplicationError> getErrors(ApplicationErrorStatus status, int pageNumber, int pageSize) {
+        checkNotNull(status, "status cannot be null");
+
+        return switch (status) {
+            case ALL -> getAllErrors(pageNumber, pageSize);
+            case RESOLVED -> getErrors(true, pageNumber, pageSize);
+            case UNRESOLVED -> getErrors(false, pageNumber, pageSize);
+        };
+    }
+
+    private List<ApplicationError> getErrors(boolean resolved, int pageNumber, int pageSize) {
+        int offset = checkPagingArgumentsAndCalculateZeroBasedOffset(pageNumber, pageSize);
+        var sql = "select * from application_errors where resolved = ? order by updated_at desc"
+                + paginationClause(pageSize, offset);
+
+        try (var conn = connection(); var ps = conn.prepareStatement(sql)) {
+            ps.setBoolean(1, resolved);
+            return collectErrors(ps, pageSize);
+        } catch (SQLException e) {
+            throw new ApplicationErrorJdbcException(e);
+        }
+    }
+
+    private static String paginationClause(int pageSize, int offset) {
+        return f(" limit {} offset {}", pageSize, offset);
+    }
+
+    @Override
+    public List<ApplicationError> getUnresolvedErrorsByDescription(String description) {
+        var sql = "select * from application_errors" +
+                " where resolved = false and description = ? order by updated_at desc";
+
+        try (var conn = connection(); var ps = conn.prepareStatement(sql)) {
+            ps.setString(1, description);
+            return collectErrors(ps, DEFAULT_PAGE_SIZE);
+        } catch (SQLException e) {
+            throw new ApplicationErrorJdbcException(e);
+        }
+    }
+
+    @Override
+    public List<ApplicationError> getUnresolvedErrorsByDescriptionAndHost(String description, String hostName) {
+        var sql = "select * from application_errors" +
+                " where resolved = false and description = ? and host_name = ? order by updated_at desc";
+
+        try (var conn = connection(); var ps = conn.prepareStatement(sql)) {
+            ps.setString(1, description);
+            ps.setString(2, hostName);
+            return collectErrors(ps, DEFAULT_PAGE_SIZE);
+        } catch (SQLException e) {
+            throw new ApplicationErrorJdbcException(e);
+        }
+    }
+
+    private static List<ApplicationError> collectErrors(PreparedStatement ps, int pageSize) throws SQLException {
+        try (var rs = ps.executeQuery()) {
+            return collectErrors(rs, pageSize);
+        }
+    }
+
+    private static List<ApplicationError> collectErrors(ResultSet rs, int pageSize) throws SQLException {
+        var errors = new ArrayList<ApplicationError>(pageSize);
+        while (rs.next()) {
+            var error = ApplicationErrorJdbc.mapFrom(rs);
+            errors.add(error);
+        }
+        return Collections.unmodifiableList(errors);
+    }
+
+    @Override
+    public long insertError(ApplicationError newError) {
+        checkArgumentIsNull(newError.getId(), "Cannot insert an ApplicationError that has an id");
+
+        var sql = "insert into application_errors" +
+                " (description, exception_type, exception_message, exception_cause_type, exception_cause_message," +
+                " stack_trace, host_name, ip_address, port)" +
+                " values (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+        try (var conn = connection(); var ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setString(1, newError.getDescription());
+            ps.setString(2, newError.getExceptionType());
+            ps.setString(3, newError.getExceptionMessage());
+            ps.setString(4, newError.getExceptionCauseType());
+            ps.setString(5, newError.getExceptionCauseMessage());
+            ps.setString(6, newError.getStackTrace());
+            ps.setString(7, newError.getHostName());
+            ps.setString(8, newError.getIpAddress());
+            ps.setInt(9, newError.getPort());
+
+            var count = ps.executeUpdate();
+            checkState(count == 1, "Insert count should be one, but is: %s", count);
+
+            try (ResultSet generatedKeys = ps.getGeneratedKeys()) {
+                nextOrThrow(generatedKeys);
+                return generatedKeys.getLong(1);
+            }
+        } catch (SQLException e) {
+            throw new ApplicationErrorJdbcException(e);
+        }
+    }
+
+    @Override
+    public void incrementCount(long id) {
+        var sql = "update application_errors" +
+                " set num_times_occurred = num_times_occurred + 1, updated_at = current_timestamp" +
+                " where id = ?";
+
+        try (var conn = connection(); var ps = conn.prepareStatement(sql)) {
+            ps.setLong(1, id);
+
+            var count = ps.executeUpdate();
+            checkState(count == 1, "Unable to increment count. No ApplicationError found with id %s", id);
+        } catch (SQLException e) {
+            throw new ApplicationErrorJdbcException(e);
+        }
+    }
+
+    @Override
+    public long insertOrIncrementCount(ApplicationError error) {
+        checkNotNull(error.getDescription(), "Error description cannot be null");
+
+        var errors = getUnresolvedErrorsByDescriptionAndHost(error.getDescription(), error.getHostName());
+
+        if (errors.isEmpty()) {
+            return insertError(error);
+        }
+
+        var existingError = first(errors);
+        incrementCount(existingError.getId());
+        return existingError.getId();
+    }
+
+    @Override
+    public ApplicationError resolve(long id) {
+        var sql = "update application_errors set resolved = true, updated_at = current_timestamp where id = ?";
+
+        try (var conn = connection(); var ps = conn.prepareStatement(sql)) {
+            ps.setLong(1, id);
+
+            var count = ps.executeUpdate();
+            checkState(count == 1, "Unable to resolve. No ApplicationError found with id %s", id);
+        } catch (SQLException e) {
+            throw new ApplicationErrorJdbcException(e);
+        }
+
+        return getById(id).orElseThrow();
+    }
+
+    @Override
+    public int resolveAllUnresolvedErrors() {
+        var sql = "update application_errors set resolved = true, updated_at = current_timestamp where resolved = false";
+
+        try (var conn = connection(); var stmt = conn.createStatement()) {
+            return stmt.executeUpdate(sql);
+        } catch (SQLException e) {
+            throw new ApplicationErrorJdbcException(e);
+        }
+    }
+
+    @Override
+    public int deleteResolvedErrorsBefore(ZonedDateTime expirationDate) {
+        var sql = "delete from application_errors where resolved = true and created_at < ?";
+        return deleteResolvedErrorsBeforeUsingQuery(sql, expirationDate);
+    }
+
+    @Override
+    public int deleteUnresolvedErrorsBefore(ZonedDateTime expirationDate) {
+        var sql = "delete from application_errors where resolved = false and created_at < ?";
+        return deleteResolvedErrorsBeforeUsingQuery(sql, expirationDate);
+    }
+
+    private int deleteResolvedErrorsBeforeUsingQuery(String sql, ZonedDateTime expirationDate) {
+        try (var conn = connection(); var ps = conn.prepareStatement(sql)) {
+            ps.setTimestamp(1, timestampFromZonedDateTime(expirationDate));
+            return ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new ApplicationErrorJdbcException(e);
+        }
+    }
+
+    private Connection connection() throws SQLException {
+        return dataSource.getConnection();
+    }
+
+}

--- a/src/test/java/org/kiwiproject/dropwizard/error/ErrorContextUtilitiesTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/ErrorContextUtilitiesTest.java
@@ -219,7 +219,6 @@ class ErrorContextUtilitiesTest {
             verifyNoMoreInteractions(healthChecks);
         }
 
-        @SuppressWarnings("ConstantValue")
         @Test
         void shouldSkipRegisteringHealthCheck() {
             options = ErrorContextOptions.builder()
@@ -269,7 +268,6 @@ class ErrorContextUtilitiesTest {
                     eq(TimeUnit.MINUTES));
         }
 
-        @SuppressWarnings("ConstantValue")
         @Test
         void shouldSkipRegisteringCleanupJob() {
             var options = ErrorContextOptions.builder()

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/jdbi3/H2Jdbi3ApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/jdbi3/H2Jdbi3ApplicationErrorDaoTest.java
@@ -1,5 +1,7 @@
 package org.kiwiproject.dropwizard.error.dao.jdbi3;
 
+import static org.kiwiproject.dropwizard.error.util.TestHelpers.shutdownH2Database;
+
 import org.h2.jdbcx.JdbcDataSource;
 import org.jdbi.v3.core.h2.H2DatabasePlugin;
 import org.junit.jupiter.api.AfterAll;
@@ -28,7 +30,7 @@ class H2Jdbi3ApplicationErrorDaoTest extends AbstractJdbi3ApplicationErrorDaoTes
 
     @AfterAll
     static void afterAll() throws SQLException {
-        ApplicationErrorJdbc.shutdownH2Database(DATA_SOURCE);
+       shutdownH2Database(DATA_SOURCE);
 
         DATA_SOURCE = null;
     }

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/AbstractJdbcApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/AbstractJdbcApplicationErrorDaoTest.java
@@ -1,0 +1,126 @@
+package org.kiwiproject.dropwizard.error.dao.jdk;
+
+import static com.google.common.base.Preconditions.checkState;
+import static org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc.nextOrThrow;
+import static org.kiwiproject.jdbc.KiwiJdbc.timestampFromZonedDateTime;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwiproject.dropwizard.error.dao.AbstractApplicationErrorDaoTest;
+import org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc;
+import org.kiwiproject.dropwizard.error.model.ApplicationError;
+import org.kiwiproject.dropwizard.error.test.junit.jupiter.ApplicationErrorExtension;
+import org.kiwiproject.test.jdbc.RuntimeSQLException;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Base test class for testing {@link JdbcApplicationErrorDao}. Used to test against different databases, currently
+ * Postgres and an in-memory H2 database.
+ * <p>
+ * NOTE: This implementation does not use transaction rollback after tests, and therefore the {@link #baseSetUpJdbc()}
+ * method deletes all application errors before each test to ensure a clean database. It would be better to use
+ * transaction rollback after each test, and faster. To do this, we might be able to use a
+ * {@link org.kiwiproject.test.jdbc.SimpleSingleConnectionDataSource SimpleSingleConnectionDataSource} to ensure that
+ * the {@link JdbcApplicationErrorDao} under test uses the same Connection throughout each test.
+ */
+@SuppressWarnings({ "SqlDialectInspection", "SqlNoDataSourceInspection" })
+@ExtendWith(ApplicationErrorExtension.class)
+@Slf4j
+public abstract class AbstractJdbcApplicationErrorDaoTest extends AbstractApplicationErrorDaoTest<JdbcApplicationErrorDao> {
+
+    // TODO: Investigate using SimpleSingleConnectionDataSource and implementing transaction rollback after each test.
+
+    protected abstract DataSource getDataSource();
+
+    @BeforeEach
+    void baseSetUpJdbc() throws SQLException {
+        deleteAllApplicationErrors();
+        countAndVerifyNoApplicationErrorsExist();
+    }
+
+    protected void deleteAllApplicationErrors() throws SQLException {
+        try (var conn = connection(); var stmt = conn.createStatement()) {
+            var count = stmt.executeUpdate("delete from application_errors");
+            LOG.info("Deleted {} application_errors", count);
+        }
+    }
+
+    @Override
+    protected JdbcApplicationErrorDao getErrorDao() {
+        return new JdbcApplicationErrorDao(getDataSource());
+    }
+
+    @Override
+    protected long insertApplicationError(ApplicationError error) {
+        var sql = "INSERT INTO application_errors"
+                + " (description, created_at, updated_at, exception_type, exception_message, exception_cause_type,"
+                + " exception_cause_message, stack_trace, resolved, host_name, ip_address, port)"
+                + " VALUES (?,?,?,?,?,?,?,?,?,?,?,?)";
+
+        try (var conn = connection(); var ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+
+            ps.setString(1, error.getDescription());
+            ps.setTimestamp(2, timestampFromZonedDateTime(error.getCreatedAt()));
+            ps.setTimestamp(3, timestampFromZonedDateTime(error.getUpdatedAt()));
+            ps.setString(4, error.getExceptionType());
+            ps.setString(5, error.getExceptionMessage());
+            ps.setString(6, error.getExceptionCauseType());
+            ps.setString(7, error.getExceptionCauseMessage());
+            ps.setString(8, error.getStackTrace());
+            ps.setBoolean(9, error.isResolved());
+            ps.setString(10, error.getHostName());
+            ps.setString(11, error.getIpAddress());
+            ps.setInt(12, error.getPort());
+
+            var count = ps.executeUpdate();
+            checkState(count == 1);
+
+            try (ResultSet generatedKeys = ps.getGeneratedKeys()) {
+                generatedKeys.next();
+                return generatedKeys.getLong(1);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeSQLException(e);
+        }
+    }
+
+    @Override
+    protected long countApplicationErrors() {
+        try (var conn = connection();
+             var stmt = conn.createStatement();
+             var rs = stmt.executeQuery("select count(*) from application_errors")) {
+
+            nextOrThrow(rs);
+            return rs.getLong(1);
+
+        } catch (SQLException e) {
+            throw new RuntimeSQLException(e);
+        }
+    }
+
+    @Override
+    protected ApplicationError getErrorOrThrow(long id) {
+        try (var conn = connection();
+             var ps = conn.prepareStatement("select * from application_errors where id  = ?")) {
+
+            ps.setLong(1, id);
+
+            try (var rs = ps.executeQuery()) {
+                nextOrThrow(rs);
+                return ApplicationErrorJdbc.mapFrom(rs);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeSQLException(e);
+        }
+    }
+
+    protected Connection connection() throws SQLException {
+        return getDataSource().getConnection();
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/H2JdbcApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/H2JdbcApplicationErrorDaoTest.java
@@ -1,5 +1,7 @@
 package org.kiwiproject.dropwizard.error.dao.jdk;
 
+import static org.kiwiproject.dropwizard.error.util.TestHelpers.shutdownH2Database;
+
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -26,8 +28,7 @@ public class H2JdbcApplicationErrorDaoTest extends AbstractJdbcApplicationErrorD
 
     @AfterAll
     static void afterAll() throws SQLException {
-
-        ApplicationErrorJdbc.shutdownH2Database(DATA_SOURCE);
+        shutdownH2Database(DATA_SOURCE);
 
         DATA_SOURCE = null;
     }

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/H2JdbcApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/H2JdbcApplicationErrorDaoTest.java
@@ -1,18 +1,16 @@
-package org.kiwiproject.dropwizard.error.dao.jdbi3;
+package org.kiwiproject.dropwizard.error.dao.jdk;
 
 import org.h2.jdbcx.JdbcDataSource;
-import org.jdbi.v3.core.h2.H2DatabasePlugin;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc;
-import org.kiwiproject.test.junit.jupiter.Jdbi3DaoExtension;
 
+import javax.sql.DataSource;
 import java.sql.SQLException;
 
-@DisplayName("Jdbi3ApplicationErrorDao (H2)")
-class H2Jdbi3ApplicationErrorDaoTest extends AbstractJdbi3ApplicationErrorDaoTest {
+@DisplayName("JdbcApplicationErrorDao (H2)")
+public class H2JdbcApplicationErrorDaoTest extends AbstractJdbcApplicationErrorDaoTest {
 
     private static JdbcDataSource DATA_SOURCE;
 
@@ -28,20 +26,14 @@ class H2Jdbi3ApplicationErrorDaoTest extends AbstractJdbi3ApplicationErrorDaoTes
 
     @AfterAll
     static void afterAll() throws SQLException {
+
         ApplicationErrorJdbc.shutdownH2Database(DATA_SOURCE);
 
         DATA_SOURCE = null;
     }
 
-    @RegisterExtension final Jdbi3DaoExtension<Jdbi3ApplicationErrorDao> jdbi3DaoExtension =
-            Jdbi3DaoExtension.<Jdbi3ApplicationErrorDao>builder()
-                    .daoType(Jdbi3ApplicationErrorDao.class)
-                    .dataSource(DATA_SOURCE)
-                    .plugin(new H2DatabasePlugin())
-                    .build();
-
     @Override
-    Jdbi3DaoExtension<Jdbi3ApplicationErrorDao> getTestExtension() {
-        return jdbi3DaoExtension;
+    protected DataSource getDataSource() {
+        return DATA_SOURCE;
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/H2JdbcApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/H2JdbcApplicationErrorDaoTest.java
@@ -2,28 +2,27 @@ package org.kiwiproject.dropwizard.error.dao.jdk;
 
 import static org.kiwiproject.dropwizard.error.util.TestHelpers.shutdownH2Database;
 
-import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc;
+import org.kiwiproject.test.jdbc.SimpleSingleConnectionDataSource;
 
-import javax.sql.DataSource;
 import java.sql.SQLException;
 
 @DisplayName("JdbcApplicationErrorDao (H2)")
 public class H2JdbcApplicationErrorDaoTest extends AbstractJdbcApplicationErrorDaoTest {
 
-    private static JdbcDataSource DATA_SOURCE;
+    private static SimpleSingleConnectionDataSource DATA_SOURCE;
 
     @BeforeAll
     static void beforeAll() {
         var dataSourceFactory = ApplicationErrorJdbc.createInMemoryH2Database();
 
-        DATA_SOURCE = new JdbcDataSource();
-        DATA_SOURCE.setUrl(dataSourceFactory.getUrl());
-        DATA_SOURCE.setUser(dataSourceFactory.getUser());
-        DATA_SOURCE.setPassword(dataSourceFactory.getPassword());
+        DATA_SOURCE = new SimpleSingleConnectionDataSource(
+                dataSourceFactory.getUrl(),
+                dataSourceFactory.getUser(),
+                dataSourceFactory.getPassword());
     }
 
     @AfterAll
@@ -34,7 +33,7 @@ public class H2JdbcApplicationErrorDaoTest extends AbstractJdbcApplicationErrorD
     }
 
     @Override
-    protected DataSource getDataSource() {
+    protected SimpleSingleConnectionDataSource getDataSource() {
         return DATA_SOURCE;
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/PostgresJdbcApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/PostgresJdbcApplicationErrorDaoTest.java
@@ -1,0 +1,20 @@
+package org.kiwiproject.dropwizard.error.dao.jdk;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.kiwiproject.test.junit.jupiter.PostgresLiquibaseTestExtension;
+
+import javax.sql.DataSource;
+
+@DisplayName("JdbcApplicationErrorDao (Postgres)")
+public class PostgresJdbcApplicationErrorDaoTest extends AbstractJdbcApplicationErrorDaoTest {
+
+    @RegisterExtension
+    static final PostgresLiquibaseTestExtension POSTGRES =
+            new PostgresLiquibaseTestExtension("dropwizard-app-errors-migrations.xml");
+
+    @Override
+    protected DataSource getDataSource() {
+        return POSTGRES.getTestDataSource();
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/PostgresJdbcApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/PostgresJdbcApplicationErrorDaoTest.java
@@ -2,9 +2,8 @@ package org.kiwiproject.dropwizard.error.dao.jdk;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.kiwiproject.test.jdbc.SimpleSingleConnectionDataSource;
 import org.kiwiproject.test.junit.jupiter.PostgresLiquibaseTestExtension;
-
-import javax.sql.DataSource;
 
 @DisplayName("JdbcApplicationErrorDao (Postgres)")
 public class PostgresJdbcApplicationErrorDaoTest extends AbstractJdbcApplicationErrorDaoTest {
@@ -14,7 +13,7 @@ public class PostgresJdbcApplicationErrorDaoTest extends AbstractJdbcApplication
             new PostgresLiquibaseTestExtension("dropwizard-app-errors-migrations.xml");
 
     @Override
-    protected DataSource getDataSource() {
+    protected SimpleSingleConnectionDataSource getDataSource() {
         return POSTGRES.getTestDataSource();
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/error/util/TestHelpers.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/util/TestHelpers.java
@@ -1,0 +1,18 @@
+package org.kiwiproject.dropwizard.error.util;
+
+import lombok.experimental.UtilityClass;
+
+import org.h2.jdbcx.JdbcDataSource;
+
+import java.sql.SQLException;
+
+@UtilityClass
+public class TestHelpers {
+
+    @SuppressWarnings({ "SqlDialectInspection", "SqlNoDataSourceInspection" })
+    public static void shutdownH2Database(JdbcDataSource h2DataSource) throws SQLException {
+        try (var conn = h2DataSource.getConnection(); var stmt = conn.createStatement()) {
+            stmt.executeUpdate("shutdown");
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/error/util/TestHelpers.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/util/TestHelpers.java
@@ -1,18 +1,32 @@
 package org.kiwiproject.dropwizard.error.util;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import lombok.experimental.UtilityClass;
 
-import org.h2.jdbcx.JdbcDataSource;
-
+import javax.sql.DataSource;
+import java.sql.Connection;
 import java.sql.SQLException;
 
 @UtilityClass
 public class TestHelpers {
 
     @SuppressWarnings({ "SqlDialectInspection", "SqlNoDataSourceInspection" })
-    public static void shutdownH2Database(JdbcDataSource h2DataSource) throws SQLException {
+    public static void shutdownH2Database(DataSource h2DataSource) throws SQLException {
         try (var conn = h2DataSource.getConnection(); var stmt = conn.createStatement()) {
+            checkIsH2Connection(conn);
             stmt.executeUpdate("shutdown");
         }
+    }
+
+    /**
+     * @implNote This checks against the Connection instead of the DataSource because the DataSource
+     * is proxied, i.e., it is a {@link org.kiwiproject.test.jdbc.SimpleSingleConnectionDataSource}
+     * so it can't just be cast to an H2 {@link org.h2.jdbcx.JdbcDataSource}.
+     */
+    private static void checkIsH2Connection(Connection conn) throws SQLException {
+        var databaseProductName = conn.getMetaData().getDatabaseProductName();
+        checkState("H2".equalsIgnoreCase(databaseProductName),
+                "Connection is not to an H2 database. Database product name: %s", databaseProductName);
     }
 }


### PR DESCRIPTION
* Add JdbcApplicationErrorDao, a plain JDBC implementation of ApplicationErrorDao
* Since the logic to map from a ResultSet is identical for the JDBC and JDBI implementations, move that logic from the Jdbi3ApplicationErrorRowMapper into ApplicationErrorJdbc in a new method 'mapFrom(ResultSet)'. Also, fix how the port is set, using rs.getInt instead of intValueOrNull, since the port field in ApplicationError is an int, not Integer
* Add new constructor accepting only a Throwable to ApplicationErrorJdbc.ApplicationErrorJdbcException
* Add a helper method to ApplicationErrorJdbc for the JDBC implementation, nextOrThrow
* Add abstract base test class, AbstractJdbcApplicationErrorDaoTest, and two subclasses for testing against H2 and Postgres. The base test class uses transaction rollback so that tests execute in a transaction but are never committed.
* Make sure to shut down the in-memory H2 database in both H2Jdbi3ApplicationErrorDaoTest and H2JdbcApplicationErrorDaoTest. Otherwise, if the H2 JDBI test runs after the JDBC one, the tests fail because they expect the database to be empty. By shutting the in-memory database down, we ensure the tests are completely isolated.
* Add TestHelpers test utility with one method, shutdownH2Database, to shut down an H2 database

Misc:

* Remove two redundant warning suppression annotations from ErrorContextUtilitiesTest

Closes #248