### PR TITLE
Add factory method to build JDBC ErrorContext; add additional factory methods

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/ErrorContextBuilder.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/ErrorContextBuilder.java
@@ -2,6 +2,7 @@ package org.kiwiproject.dropwizard.error;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc.createInMemoryH2Database;
 import static org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc.isH2EmbeddedDataStore;
@@ -28,15 +29,18 @@ import java.time.temporal.TemporalUnit;
 /**
  * Builder for {@link ErrorContext} implementations.
  * <p>
- * To start building, you call {@link #newInstance()}. After that, there must be at the minimum three methods used:
+ * To start building, you call {@link #newInstance()}.
+ * After that, there must be at minimum three methods used:
  * <ol>
  * <li>{@link #environment(Environment)}</li>
  * <li>{@link #serviceDetails(ServiceDetails)}</li>
  * <li>And one of:
  * <ul>
  * <li>{@link #buildInMemoryH2()}</li>
- * <li>{@link #buildWithDataStoreFactory(DataSourceFactory)}</li>
+ * <li>{@link #buildWithJdbc(DataSourceFactory)}</li>
  * <li>{@link #buildWithJdbi3(Jdbi)}</li>
+ * <li>{@link #buildWithJdbi3(DataSourceFactory)}</li>
+ * <li>{@link #buildWithDataStoreFactoryOfType(DataSourceFactory, DaoType)}</li>
  * <li>{@link #buildWithNoOpDao()}</li>
  * <li>{@link #buildWithConcurrentMapDao()}</li>
  * <li>{@link #buildWithDao(ApplicationErrorDao)}</li>
@@ -68,20 +72,24 @@ import java.time.temporal.TemporalUnit;
  * </pre>
  * <p>
  * All the terminal build methods use {@link DataStoreType} to determine if the {@link ErrorContext} instance is
- * {@link DataStoreType#SHARED shared} (i.e. multiple instances of the same service read and write to the same database)
- * or {@link DataStoreType#NOT_SHARED not shared} (i.e. each service instance has its own segregated database). You can
- * change the defaults (listed below) by explicitly calling the {@link #dataStoreType(DataStoreType)} method with the
+ * {@link DataStoreType#SHARED shared} (i.e., multiple instances of the same service read and write to the same database)
+ * or {@link DataStoreType#NOT_SHARED not shared} (i.e., each service instance has its own segregated database).
+ * You can change the defaults (listed below) by explicitly calling the {@link #dataStoreType(DataStoreType)} method with the
  * store type you want.
- * Defaults:
+ * <p>
+ * The <em>defaults</em> when DataStoreType is not set are determined as follows for the {@code buildWith} methods:
  * <ul>
- * <li>{@link #buildInMemoryH2()}: {@link DataStoreType#NOT_SHARED} (<b>NOTE:</b> this cannot be overridden)</li>
- * <li>{@link #buildWithDataStoreFactory(DataSourceFactory)}
- * <ul>
- * <li>If the database defined by the {@link DataSourceFactory} is an H2 instance , then {@link DataStoreType#NOT_SHARED}</li>
- * <li>Otherwise, {@link DataStoreType#SHARED}</li>
- * </ul>
- * </li>
- * <li>{@link #buildWithJdbi3(Jdbi)}: {@link DataStoreType#SHARED}</li>
+ *     <li>{@link #buildInMemoryH2()}: {@link DataStoreType#NOT_SHARED} (<b>NOTE:</b> this cannot be overridden)</li>
+ *     <li>{@link #buildWithJdbi3(Jdbi)}: {@link DataStoreType#SHARED}</li>
+ *     <li>All other {@code buildWith} methods:
+ *         <ul>
+ *             <li>
+ *                 If the database defined by the {@link DataSourceFactory} is an embedded H2 instance,
+ *                 then {@link DataStoreType#NOT_SHARED}
+ *             </li>
+ *             <li>Otherwise, {@link DataStoreType#SHARED}</li>
+ *         </ul>
+ *     </li>
  * </ul>
  */
 @Slf4j
@@ -202,7 +210,7 @@ public class ErrorContextBuilder {
 
     /**
      * Configures the {@link TimeWindow} for the health check. If an error occurs within this time window, the
-     * health check will report as unhealthy. If there are no errors inside of this window, the health check will
+     * health check will report as unhealthy. If there are no errors inside this window, the health check will
      * report as healthy.
      *
      * @param timeWindow the {@link TimeWindow}
@@ -223,7 +231,7 @@ public class ErrorContextBuilder {
 
     /**
      * Configures the length of time for the health check. If an error occurs within this time window, the
-     * health check will report as unhealthy. If there are no errors inside of this window, the health check will
+     * health check will report as unhealthy. If there are no errors inside this window, the health check will
      * report as healthy.
      *
      * @param timeWindowValue the length of time
@@ -242,7 +250,7 @@ public class ErrorContextBuilder {
 
     /**
      * Configures the {@link TemporalUnit} for the health check. If an error occurs within this time window, the
-     * health check will report as unhealthy. If there are no errors inside of this window, the health check will
+     * health check will report as unhealthy. If there are no errors inside this window, the health check will
      * report as healthy.
      *
      * @param timeWindowUnit the {@link TemporalUnit}
@@ -297,8 +305,23 @@ public class ErrorContextBuilder {
      * @implNote If you do not invoke {@link #dataStoreType(DataStoreType)} prior to calling this method, this method
      * will attempt to determine which {@link DataStoreType} it should use by calling
      * {@link ApplicationErrorJdbc#dataStoreTypeOf(DataSourceFactory)}.
+     * @deprecated use {@link #buildWithJdbi3(DataSourceFactory)}
      */
+    @Deprecated(since = "2.1.0")
     public ErrorContext buildWithDataStoreFactory(DataSourceFactory dataSourceFactory) {
+        return buildWithJdbi3(dataSourceFactory);
+    }
+
+    /**
+     * Build an {@link ErrorContext} using given the {@code dataSourceFactory} that uses JDBI version 3.
+     *
+     * @param dataSourceFactory the Dropwizard {@link DataSourceFactory}
+     * @return a new {@link ErrorContext} instance
+     * @implNote If you do not invoke {@link #dataStoreType(DataStoreType)} prior to calling this method, this method
+     * will attempt to determine which {@link DataStoreType} it should use by calling
+     * {@link ApplicationErrorJdbc#dataStoreTypeOf(DataSourceFactory)}.
+     */
+    public ErrorContext buildWithJdbi3(DataSourceFactory dataSourceFactory) {
         ensureDataStoreTypeIsSetFor(dataSourceFactory);
 
         // Check arguments before creating Jdbi instance
@@ -320,7 +343,7 @@ public class ErrorContextBuilder {
      * will attempt to determine which {@link DataStoreType} it should use by calling
      * {@link ApplicationErrorJdbc#dataStoreTypeOf(DataSourceFactory)}.
      */
-    public ErrorContext buildJdbcWithDataSourceFactory(DataSourceFactory dataSourceFactory) {
+    public ErrorContext buildWithJdbc(DataSourceFactory dataSourceFactory) {
         ensureDataStoreTypeIsSetFor(dataSourceFactory);
 
         // Check arguments before creating DataSource and DAO
@@ -333,6 +356,42 @@ public class ErrorContextBuilder {
         var errorDao = new JdbcApplicationErrorDao(managedDataSource);
 
         return buildWithDao(errorDao);
+    }
+
+    /**
+     * The DaoType enum represents the different types of data access objects (DAOs)
+     * for an {@link ErrorContext}.
+     */
+    public enum DaoType {
+
+        /**
+         * The DAO implementation uses plain JDBC.
+         */
+        JDBC,
+
+        /**
+         * The DAO implementation uses JDBI 3.
+         */
+        JDBI3
+    }
+
+    /**
+     * Build an {@link ErrorContext} using the {@code dataSourceFactory} of a specified {@code daoType}.
+     *
+     * @param dataSourceFactory the Dropwizard {@link DataSourceFactory}
+     * @param daoType           the type of DAO to use for error context creation
+     * @return a new {@link ErrorContext} instance
+     * @throws IllegalArgumentException if the {@code daoType} is null
+     * @implNote If you do not invoke {@link #dataStoreType(DataStoreType)} prior to calling this method, this method
+     * will attempt to determine which {@link DataStoreType} it should use by calling
+     * {@link ApplicationErrorJdbc#dataStoreTypeOf(DataSourceFactory)}.
+     */
+    public ErrorContext buildWithDataStoreFactoryOfType(DataSourceFactory dataSourceFactory, DaoType daoType) {
+        checkArgumentNotNull(daoType, "daoType must not be null");
+        return switch (daoType) {
+            case JDBC -> buildWithJdbc(dataSourceFactory);
+            case JDBI3 -> buildWithJdbi3(dataSourceFactory);
+        };
     }
 
     private void ensureDataStoreTypeIsSetFor(DataSourceFactory dataSourceFactory) {

--- a/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbc.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbc.java
@@ -117,7 +117,7 @@ public class ApplicationErrorJdbc {
                 .addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, liquibaseDatabase)
                 .addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, MIGRATIONS_FILENAME);
         var updateResults = updateCommand.execute();
-        LOG.debug("Update results: {}", updateResults.getResults());
+        LOG.debug("Liquibase update results: {}", updateResults.getResults());
     }
 
     @VisibleForTesting

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbcTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbcTest.java
@@ -173,12 +173,13 @@ class ApplicationErrorJdbcTest {
 
                 ApplicationErrorJdbc.migrateDatabase(conn);
 
-                var stmt = conn.createStatement();
-                var rs = stmt.executeQuery("select * from databasechangelog");
-                nextOrThrow(rs);
+                try (var stmt = conn.createStatement()) {
+                    var rs = stmt.executeQuery("select * from databasechangelog");
+                    nextOrThrow(rs);
 
-                var filename = rs.getString("filename");
-                assertThat(filename).isEqualTo("dropwizard-app-errors-migrations.xml");
+                    var filename = rs.getString("filename");
+                    assertThat(filename).isEqualTo("dropwizard-app-errors-migrations.xml");
+                }
             }
         }
 


### PR DESCRIPTION
* Add buildWithJdbc to ErrorContextBuilder
* Deprecate buildWithDataStoreFactory since the argument does not
  tell you what kind of DAO it will use (JDBI 3), and is therefore
  not indicative of function
* Add buildWithJdbi3(DataSourceFactory), which replaces the
  deprecated method, since it is clear it will use the
  DataSourceFactory argument to create an ErrorContext that
  uses a JDBI 3 DAO implementation
* Add buildWithDataStoreFactoryOfType which accepts a
  DataStoreFactory and a DaoType, which is a new enum that
  has values for JDBC and JBI 3
* Extract checkCommonArguments method to reduce duplication
* Extract ensureDataStoreTypeIsSetFor to reduce duplication
* Minor log message enhancement in ApplicationErrorJdbc
* Update tests to accommodate renaming, and add new test for
  the new buildWithDataStoreFactoryOfType method
* Update the javadocs with information about the new factory
  methods
* Fix minor grammatical errors

Closes #317