### PR TITLE
Replace nextOrThrow in ApplicationErrorJdbc with one from KiwiJdbc

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbc.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbc.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.dropwizard.error.dao;
 
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.isNull;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -213,10 +212,6 @@ public class ApplicationErrorJdbc {
                 .ipAddress(rs.getString("ip_address"))
                 .port(rs.getInt("port"))
                 .build();
-    }
-
-    public static void nextOrThrow(ResultSet rs) throws SQLException {
-        checkState(rs.next(), "ResultSet.next() returned false");
     }
 
     /**

--- a/src/main/java/org/kiwiproject/dropwizard/error/dao/jdk/JdbcApplicationErrorDao.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/dao/jdk/JdbcApplicationErrorDao.java
@@ -6,7 +6,7 @@ import static org.kiwiproject.base.KiwiPreconditions.checkArgumentIsNull;
 import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.collect.KiwiLists.first;
 import static org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao.checkPagingArgumentsAndCalculateZeroBasedOffset;
-import static org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc.nextOrThrow;
+import static org.kiwiproject.jdbc.KiwiJdbc.nextOrThrow;
 import static org.kiwiproject.jdbc.KiwiJdbc.timestampFromZonedDateTime;
 
 import org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao;

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbcTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbcTest.java
@@ -1,15 +1,10 @@
 package org.kiwiproject.dropwizard.error.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc.nextOrThrow;
+import static org.kiwiproject.jdbc.KiwiJdbc.nextOrThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.only;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import io.dropwizard.db.DataSourceFactory;
 import org.h2.Driver;
@@ -29,7 +24,6 @@ import org.kiwiproject.test.junit.jupiter.ClearBoxTest;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
 @DisplayName("ApplicationErrorJdbc")
@@ -314,38 +308,6 @@ class ApplicationErrorJdbcTest {
             dataSourceFactory.setDriverClass(Driver.class.getName());
             dataSourceFactory.setUrl(url);
             assertThat(ApplicationErrorJdbc.isH2EmbeddedDataStore(dataSourceFactory)).isEqualTo(isEmbeddedUrl);
-        }
-    }
-
-    @Nested
-    class NextOrThrow {
-
-        private ResultSet resultSet;
-
-        @BeforeEach
-        void setUp() {
-            resultSet = mock(ResultSet.class);
-        }
-
-        @Test
-        void shouldAdvanceResultSet() throws SQLException {
-            when(resultSet.next()).thenReturn(true);
-
-            assertThatCode(() -> ApplicationErrorJdbc.nextOrThrow(resultSet))
-                    .doesNotThrowAnyException();
-
-            verify(resultSet, only()).next();
-        }
-
-        @Test
-        void shouldThrowIllegalState_WhenNextReturnsFalse() throws SQLException {
-            when(resultSet.next()).thenReturn(false);
-
-            assertThatIllegalStateException()
-                    .isThrownBy(() -> ApplicationErrorJdbc.nextOrThrow(resultSet))
-                    .withMessage("ResultSet.next() returned false");
-
-            verify(resultSet, only()).next();
         }
     }
 

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/AbstractJdbcApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/AbstractJdbcApplicationErrorDaoTest.java
@@ -1,7 +1,7 @@
 package org.kiwiproject.dropwizard.error.dao.jdk;
 
 import static com.google.common.base.Preconditions.checkState;
-import static org.kiwiproject.dropwizard.error.dao.ApplicationErrorJdbc.nextOrThrow;
+import static org.kiwiproject.jdbc.KiwiJdbc.nextOrThrow;
 import static org.kiwiproject.jdbc.KiwiJdbc.timestampFromZonedDateTime;
 
 import org.junit.jupiter.api.AfterEach;


### PR DESCRIPTION
* Replace usages of ApplicationErrorJdbc#nextOrThrow with the one from KiwiJdbc
* Remove the nextOrThrow method from ApplicationErrorJdbc; this was never in an actual release so doesn't break any existing code and doesn't require a major version bump
* Remove the nextOrThrow tests from ApplicationErrorJdbcTest; we don't need to test it anymore since it's now the one in KiwiJdbc

Closes #321