### PR TITLE
Update test logging config to log TRACE level only for this library

### DIFF
--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -6,7 +6,7 @@
             </pattern>
         </encoder>
     </appender>
-    <logger name="org.kiwiproject" level="TRACE"/>
+    <logger name="org.kiwiproject.dropwizard.error" level="TRACE"/>
     <logger name="liquibase" level="INFO"/>
     <root level="WARN">
         <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
We don't want TRACE level for any org.kiwiproject package!