### PR TITLE
Configure Surefire plugin to use UTC as default time zone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,4 +197,26 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+
+            <!--
+            Set the default time zone to UTC when running tests.
+            Otherwise, certain tests will fail due to differences
+            in how some databases handle time zones.
+
+            For example, MySQL and SQLite handle them differently
+            from Postgres and H2.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Duser.timezone=UTC</argLine>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
* In pom.xml set the JVM time zone to UTC when running tests
* Log a warning in AbstractApplicationErrorDaoTest when the timestamp assertions fail, explaining that it is probably a timezone problem. This should only occur when using something other than Maven and IntelliJ to run tests, such as VSCode which doesn't apply the Surefire plugin configuration when running tests via its test runner. IntelliJ is smarter and automatically applies the configuration when running tests via its test runner.