### PR TITLE
Temporary: comment the Surefire configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,13 +208,16 @@
             For example, MySQL and SQLite handle them differently
             from Postgres and H2.
             -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>-Duser.timezone=UTC</argLine>
-                </configuration>
-            </plugin>
+            <!-- TEMPORARY: Investigating why this causes jacoco to have no coverage info. -->
+            <!--
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <argLine>-Duser.timezone=UTC</argLine>
+                            </configuration>
+                        </plugin>
+            -->
 
         </plugins>
     </build>


### PR DESCRIPTION
After applying the timezone config to Surefire, suddenly there are no test coverage results. The target/site/jacoco directory simply doesn't exist. This happens locally as well. This is a temporary reversion until I can figure out why adding a Surefire configuration caused there to be no coverage info!