### PR TITLE
Sonar cleanup

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/error/config/CleanupConfigTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/config/CleanupConfigTest.java
@@ -27,8 +27,6 @@ class CleanupConfigTest {
 
     @Test
     void shouldHaveDefaults() {
-        var config = new CleanupConfig();
-
         assertAll(
             () -> assertThat(config.getCleanupStrategy()).isEqualTo(CleanupConfig.CleanupStrategy.ALL_ERRORS),
             () -> assertThat(config.getResolvedErrorExpiration()).isEqualTo(Duration.days(14)),

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/AbstractApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/AbstractApplicationErrorDaoTest.java
@@ -1,7 +1,6 @@
 package org.kiwiproject.dropwizard.error.dao;
 
 import static com.google.common.base.Verify.verify;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
@@ -695,8 +694,8 @@ public abstract class AbstractApplicationErrorDaoTest<T extends ApplicationError
 
         @Test
         void shouldNotChangeOtherFields_OnExistingError(SoftAssertions softly) {
-            var description = "uh oh uh oh";
-            var id = insertApplicationError(ApplicationError.newUnresolvedError(description));
+            var desc = "uh oh uh oh";
+            var id = insertApplicationError(ApplicationError.newUnresolvedError(desc));
             softlyAssertNumTimesOccurred(softly, id, 1);
 
             var originalError = getErrorOrThrow(id);
@@ -727,7 +726,7 @@ public abstract class AbstractApplicationErrorDaoTest<T extends ApplicationError
     private List<Long> insertErrorsWithResolvedAs(int count, Resolved resolved, String host) {
         return IntStream.rangeClosed(1, count).mapToObj(value ->
                         insertApplicationError(randomApplicationErrorWithResolvedAndHost(resolved, host)))
-                .collect(toList());
+                .toList();
     }
 
     private ApplicationError defaultApplicationError() {
@@ -752,8 +751,8 @@ public abstract class AbstractApplicationErrorDaoTest<T extends ApplicationError
 
     private ApplicationError randomApplicationErrorWithResolvedAndHost(Resolved resolved, String hostName) {
         var number = random.nextInt(100_000);
-        var throwable = newThrowable("message " + number, "cause message " + number);
-        return ApplicationError.newError(description + " " + number, resolved, hostName, ipAddress, port, throwable);
+        var error = newThrowable("message " + number, "cause message " + number);
+        return ApplicationError.newError(description + " " + number, resolved, hostName, ipAddress, port, error);
     }
 
     private ApplicationError newApplicationError(String description, Resolved resolved) {

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbcTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/ApplicationErrorJdbcTest.java
@@ -44,7 +44,7 @@ class ApplicationErrorJdbcTest {
 
         @Test
         void shouldCreateInMemoryDatabase() {
-            var dataSourceFactory = ApplicationErrorJdbc.createInMemoryH2Database();
+            dataSourceFactory = ApplicationErrorJdbc.createInMemoryH2Database();
 
             var url = dataSourceFactory.getUrl();
             var user = dataSourceFactory.getUser();
@@ -81,7 +81,7 @@ class ApplicationErrorJdbcTest {
 
         @ClearBoxTest
         void shouldGetDatabaseProductName() throws SQLException {
-            var dataSourceFactory = ApplicationErrorJdbc.createInMemoryH2Database();
+            dataSourceFactory = ApplicationErrorJdbc.createInMemoryH2Database();
 
             var url = dataSourceFactory.getUrl();
             var user = dataSourceFactory.getUser();
@@ -95,7 +95,7 @@ class ApplicationErrorJdbcTest {
 
         @ClearBoxTest
         void shouldReturnUnknownIfExceptionThrown() throws SQLException {
-            var dataSourceFactory = ApplicationErrorJdbc.createInMemoryH2Database();
+            dataSourceFactory = ApplicationErrorJdbc.createInMemoryH2Database();
 
             var url = dataSourceFactory.getUrl();
             var user = dataSourceFactory.getUser();
@@ -204,7 +204,6 @@ class ApplicationErrorJdbcTest {
                 "jdbc:sqlite:sample.db"
         })
         void shouldReturnFalse_WhenDriverIsH2_ButUrlIsNotH2(String jdbcUrl) {
-            var dataSourceFactory = new DataSourceFactory();
             dataSourceFactory.setDriverClass(Driver.class.getName());
             dataSourceFactory.setUrl(jdbcUrl);
             assertThat(ApplicationErrorJdbc.isH2DataStore(dataSourceFactory)).isFalse();
@@ -217,7 +216,6 @@ class ApplicationErrorJdbcTest {
                 "org.acme.db.Driver"
         })
         void shouldReturnFalse_WhenGivenNonH2DataSourceFactory(String value) {
-            var dataSourceFactory = new DataSourceFactory();
             dataSourceFactory.setDriverClass(value);
             assertThat(ApplicationErrorJdbc.isH2DataStore(dataSourceFactory)).isFalse();
         }
@@ -229,7 +227,6 @@ class ApplicationErrorJdbcTest {
                 "jdbc:h2:tcp://localhost/~/test"
         })
         void shouldReturnTrue_WhenGivenH2DataSourceFactory(String jdbcUrl) {
-            var dataSourceFactory = new DataSourceFactory();
             dataSourceFactory.setDriverClass(Driver.class.getName());
             dataSourceFactory.setUrl(jdbcUrl);
             assertThat(ApplicationErrorJdbc.isH2DataStore(dataSourceFactory)).isTrue();
@@ -254,7 +251,6 @@ class ApplicationErrorJdbcTest {
                 org.h2.Driver, null
                 """, nullValues = "null")
         void shouldReturnFalse_WhenGivenNonH2_DataSourceFactory(String driverClass, String jdbcUrl) {
-            var dataSourceFactory = new DataSourceFactory();
             dataSourceFactory.setDriverClass(driverClass);
             dataSourceFactory.setUrl(jdbcUrl);
             assertThat(ApplicationErrorJdbc.isH2EmbeddedDataStore(dataSourceFactory)).isFalse();
@@ -267,7 +263,6 @@ class ApplicationErrorJdbcTest {
                 "org.acme.db.Driver"
         })
         void shouldReturnFalse_WhenGivenNonH2DataSourceFactory(String value) {
-            var dataSourceFactory = new DataSourceFactory();
             dataSourceFactory.setDriverClass(value);
             assertThat(ApplicationErrorJdbc.isH2EmbeddedDataStore(dataSourceFactory)).isFalse();
         }
@@ -304,7 +299,6 @@ class ApplicationErrorJdbcTest {
                 jdbc:h2:/data/test;auto_server=true, false
                 """)
         void shouldReturnTrue_WhenGivenEmbeddedH2DataSourceFactory(String url, boolean isEmbeddedUrl) {
-            var dataSourceFactory = new DataSourceFactory();
             dataSourceFactory.setDriverClass(Driver.class.getName());
             dataSourceFactory.setUrl(url);
             assertThat(ApplicationErrorJdbc.isH2EmbeddedDataStore(dataSourceFactory)).isEqualTo(isEmbeddedUrl);

--- a/src/test/java/org/kiwiproject/dropwizard/error/health/RecentErrorsHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/health/RecentErrorsHealthCheckTest.java
@@ -76,7 +76,7 @@ class RecentErrorsHealthCheckTest {
                 "72, HOURS, 3 days",
         })
         void fromAmountAndChronoUnit(long windowAmount, ChronoUnit windowUnit, String expectedReadableWindow) {
-            var healthCheck = newHealthCheck(windowAmount, windowUnit);
+            healthCheck = newHealthCheck(windowAmount, windowUnit);
 
             assertThat(healthCheck.getTimeWindowAmount()).isEqualTo(windowAmount);
             assertThat(healthCheck.getTimeWindowUnit()).isEqualTo(windowUnit);
@@ -99,7 +99,7 @@ class RecentErrorsHealthCheckTest {
         })
         void fromTimeWindowObject(String durationString, String expectedReadableWindow) {
             var duration = Duration.parse(durationString);
-            var healthCheck = newHealthCheck(new TimeWindow(duration));
+            healthCheck = newHealthCheck(new TimeWindow(duration));
 
             var javaTimeDuration = duration.toJavaDuration();
             assertThat(healthCheck.getTimeWindowAmount()).isEqualTo(javaTimeDuration.toMillis());
@@ -123,7 +123,7 @@ class RecentErrorsHealthCheckTest {
         })
         void fromDropwizardDuration(String durationString, String expectedReadableWindow) {
             var duration = Duration.parse(durationString);
-            var healthCheck = newHealthCheck(duration);
+            healthCheck = newHealthCheck(duration);
 
             assertThat(healthCheck.getTimeWindow()).isEqualTo(duration.toJavaDuration());
             assertThat(healthCheck.getHumanReadableTimeWindow()).isEqualTo(expectedReadableWindow);

--- a/src/test/java/org/kiwiproject/dropwizard/error/model/ApplicationErrorTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/model/ApplicationErrorTest.java
@@ -178,11 +178,11 @@ class ApplicationErrorTest {
 
         @Test
         void shouldCreateWithOnlyDescription_AndPresetPersistentHostInformation(SoftAssertions softly) {
-            error = ApplicationError.newUnresolvedError(description, throwable);
+            error = ApplicationError.newUnresolvedError(description);
 
             softly.assertThat(error.isResolved()).isFalse();
             assertCommonProperties(softly);
-            assertExceptionProperties(softly);
+            assertNoExceptionProperties(softly);
         }
 
         @Test
@@ -246,7 +246,7 @@ class ApplicationErrorTest {
                                      String ipAddress,
                                      int port,
                                      String expectedErrorMessage) {
-            
+
             assertThatThrownBy(() ->
                     ApplicationError.newError(description, resolved, hostName, ipAddress, port, null))
                     .isExactlyInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/org/kiwiproject/dropwizard/error/resource/ApplicationErrorResourceTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/resource/ApplicationErrorResourceTest.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.dropwizard.error.resource;
 
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertInternalServerErrorResponse;
 import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertNotFoundResponse;
@@ -99,7 +98,7 @@ class ApplicationErrorResourceTest {
                         var randomBoolean = ThreadLocalRandom.current().nextBoolean();
                         return newApplicationError("error " + value, Resolved.of(randomBoolean));
                     })
-                    .collect(toList());
+                    .toList();
 
             when(ERROR_DAO.getErrors(ApplicationErrorStatus.ALL, pageNumber, pageSize)).thenReturn(errors);
             when(ERROR_DAO.count(ApplicationErrorStatus.ALL)).thenReturn(totalCount);
@@ -121,7 +120,7 @@ class ApplicationErrorResourceTest {
             var totalCount = 42L;
             var errors = IntStream.rangeClosed(1, pageSize)
                     .mapToObj(value -> newApplicationError("error " + value, Resolved.NO))
-                    .collect(toList());
+                    .toList();
 
             when(ERROR_DAO.getErrors(ApplicationErrorStatus.UNRESOLVED, pageNumber, pageSize)).thenReturn(errors);
             when(ERROR_DAO.count(ApplicationErrorStatus.UNRESOLVED)).thenReturn(totalCount);
@@ -143,7 +142,7 @@ class ApplicationErrorResourceTest {
             var totalCount = 42L;
             var errors = IntStream.rangeClosed(1, pageSize)
                     .mapToObj(value -> newApplicationError("error " + value, Resolved.YES))
-                    .collect(toList());
+                    .toList();
 
             when(ERROR_DAO.getErrors(ApplicationErrorStatus.RESOLVED, pageNumber, pageSize)).thenReturn(errors);
             when(ERROR_DAO.count(ApplicationErrorStatus.RESOLVED)).thenReturn(totalCount);
@@ -231,7 +230,7 @@ class ApplicationErrorResourceTest {
         assertThat(applicationErrors.getPageSize()).isEqualTo(expectedPageSize);
         assertThat(applicationErrors.getTotalCount()).isEqualTo(expectedTotalCount);
 
-        List<String> errorDescriptions = expectedErrors.stream().map(ApplicationError::getDescription).collect(toList());
+        List<String> errorDescriptions = expectedErrors.stream().map(ApplicationError::getDescription).toList();
 
         assertThat(applicationErrors.getItems())
                 .describedAs("should have %d errors with matching descriptions", expectedPageSize)


### PR DESCRIPTION
Sonar cleanup
* Local variables should not shadow class fields java:S1117
* "Stream.toList()" method should be used instead of "collectors" when unmodifiable list needed java:S6204
* Methods should not have identical implementations java:S4144