### PR TITLE
Sonar: rename fields idiomatically

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/jdbi3/H2Jdbi3ApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/jdbi3/H2Jdbi3ApplicationErrorDaoTest.java
@@ -16,29 +16,29 @@ import java.sql.SQLException;
 @DisplayName("Jdbi3ApplicationErrorDao (H2)")
 class H2Jdbi3ApplicationErrorDaoTest extends AbstractJdbi3ApplicationErrorDaoTest {
 
-    private static JdbcDataSource DATA_SOURCE;
+    private static JdbcDataSource dataSource;
 
     @BeforeAll
     static void beforeAll() {
         var dataSourceFactory = ApplicationErrorJdbc.createInMemoryH2Database();
 
-        DATA_SOURCE = new JdbcDataSource();
-        DATA_SOURCE.setUrl(dataSourceFactory.getUrl());
-        DATA_SOURCE.setUser(dataSourceFactory.getUser());
-        DATA_SOURCE.setPassword(dataSourceFactory.getPassword());
+        dataSource = new JdbcDataSource();
+        dataSource.setUrl(dataSourceFactory.getUrl());
+        dataSource.setUser(dataSourceFactory.getUser());
+        dataSource.setPassword(dataSourceFactory.getPassword());
     }
 
     @AfterAll
     static void afterAll() throws SQLException {
-       shutdownH2Database(DATA_SOURCE);
+       shutdownH2Database(dataSource);
 
-        DATA_SOURCE = null;
+        dataSource = null;
     }
 
     @RegisterExtension final Jdbi3DaoExtension<Jdbi3ApplicationErrorDao> jdbi3DaoExtension =
             Jdbi3DaoExtension.<Jdbi3ApplicationErrorDao>builder()
                     .daoType(Jdbi3ApplicationErrorDao.class)
-                    .dataSource(DATA_SOURCE)
+                    .dataSource(dataSource)
                     .plugin(new H2DatabasePlugin())
                     .build();
 

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/jdbi3/SqliteJdbi3ApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/jdbi3/SqliteJdbi3ApplicationErrorDaoTest.java
@@ -12,19 +12,19 @@ import org.kiwiproject.test.junit.jupiter.Jdbi3DaoExtension;
 @DisplayName("Jdbi3ApplicationErrorDao (SQLite)")
 class SqliteJdbi3ApplicationErrorDaoTest extends AbstractJdbi3ApplicationErrorDaoTest {
 
-    private static SimpleSingleConnectionDataSource DATA_SOURCE;
+    private static SimpleSingleConnectionDataSource dataSource;
 
     @BeforeAll
     static void beforeAll() {
-        DATA_SOURCE = newInMemorySqliteDataSource();
-        migrateDatabase(DATA_SOURCE, "dropwizard-app-errors-migrations-sqlite.xml");
+        dataSource = newInMemorySqliteDataSource();
+        migrateDatabase(dataSource, "dropwizard-app-errors-migrations-sqlite.xml");
     }
 
     @RegisterExtension
     final Jdbi3DaoExtension<Jdbi3ApplicationErrorDao> jdbi3DaoExtension =
             Jdbi3DaoExtension.<Jdbi3ApplicationErrorDao>builder()
                     .daoType(Jdbi3ApplicationErrorDao.class)
-                    .dataSource(DATA_SOURCE)
+                    .dataSource(dataSource)
                     .build();
 
     @Override

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/H2JdbcApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/H2JdbcApplicationErrorDaoTest.java
@@ -13,13 +13,13 @@ import java.sql.SQLException;
 @DisplayName("JdbcApplicationErrorDao (H2)")
 public class H2JdbcApplicationErrorDaoTest extends AbstractJdbcApplicationErrorDaoTest {
 
-    private static SimpleSingleConnectionDataSource DATA_SOURCE;
+    private static SimpleSingleConnectionDataSource dataSource;
 
     @BeforeAll
     static void beforeAll() {
         var dataSourceFactory = ApplicationErrorJdbc.createInMemoryH2Database();
 
-        DATA_SOURCE = new SimpleSingleConnectionDataSource(
+        dataSource = new SimpleSingleConnectionDataSource(
                 dataSourceFactory.getUrl(),
                 dataSourceFactory.getUser(),
                 dataSourceFactory.getPassword());
@@ -27,13 +27,13 @@ public class H2JdbcApplicationErrorDaoTest extends AbstractJdbcApplicationErrorD
 
     @AfterAll
     static void afterAll() throws SQLException {
-        shutdownH2Database(DATA_SOURCE);
+        shutdownH2Database(dataSource);
 
-        DATA_SOURCE = null;
+        dataSource = null;
     }
 
     @Override
     protected SimpleSingleConnectionDataSource getDataSource() {
-        return DATA_SOURCE;
+        return dataSource;
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/MySqlJdbcApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/MySqlJdbcApplicationErrorDaoTest.java
@@ -14,7 +14,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @DisplayName("JdbcApplicationErrorDao (MySQL)")
 class MySqlJdbcApplicationErrorDaoTest extends AbstractJdbcApplicationErrorDaoTest {
 
-    private static SimpleSingleConnectionDataSource DATA_SOURCE;
+    private static SimpleSingleConnectionDataSource dataSource;
 
     @Container
     private static final MySQLContainer<?> MYSQL = newLatestMySQLContainer();
@@ -23,12 +23,12 @@ class MySqlJdbcApplicationErrorDaoTest extends AbstractJdbcApplicationErrorDaoTe
     static void beforeAll() {
         migrateDatabase(MYSQL, "dropwizard-app-errors-migrations-mysql.xml");
 
-        DATA_SOURCE = new SimpleSingleConnectionDataSource(
+        dataSource = new SimpleSingleConnectionDataSource(
             MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword());
     }
 
     @Override
     protected SimpleSingleConnectionDataSource getDataSource() {
-        return DATA_SOURCE;
+        return dataSource;
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/SqliteJdbcApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/SqliteJdbcApplicationErrorDaoTest.java
@@ -10,16 +10,16 @@ import org.kiwiproject.test.jdbc.SimpleSingleConnectionDataSource;
 @DisplayName("JdbcApplicationErrorDao (SQLite)")
 class SqliteJdbcApplicationErrorDaoTest extends AbstractJdbcApplicationErrorDaoTest {
 
-    private static SimpleSingleConnectionDataSource DATA_SOURCE;
+    private static SimpleSingleConnectionDataSource dataSource;
 
     @BeforeAll
     static void beforeAll() {
-        DATA_SOURCE = newInMemorySqliteDataSource();
-        migrateDatabase(DATA_SOURCE, "dropwizard-app-errors-migrations-sqlite.xml");
+        dataSource = newInMemorySqliteDataSource();
+        migrateDatabase(dataSource, "dropwizard-app-errors-migrations-sqlite.xml");
     }
 
     @Override
     protected SimpleSingleConnectionDataSource getDataSource() {
-        return DATA_SOURCE;
+        return dataSource;
     }
 }


### PR DESCRIPTION
* Rename non-final static fields in several tests from DATA_SOURCE to dataSource. The field cannot be final b/c they are set up in the BeforeAll method.