### PR TITLE
Switch to mysql:lts container

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/jdbi3/MySqlJdbi3ApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/jdbi3/MySqlJdbi3ApplicationErrorDaoTest.java
@@ -1,7 +1,7 @@
 package org.kiwiproject.dropwizard.error.dao.jdbi3;
 
 import static org.kiwiproject.dropwizard.error.util.TestHelpers.migrateDatabase;
-import static org.kiwiproject.dropwizard.error.util.TestHelpers.newLatestMySQLContainer;
+import static org.kiwiproject.dropwizard.error.util.TestHelpers.newLtsMySQLContainer;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +16,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 class MySqlJdbi3ApplicationErrorDaoTest extends AbstractJdbi3ApplicationErrorDaoTest {
 
     @Container
-    private static final MySQLContainer<?> MYSQL = newLatestMySQLContainer();
+    private static final MySQLContainer<?> MYSQL = newLtsMySQLContainer();
 
     @RegisterExtension
     final Jdbi3DaoExtension<Jdbi3ApplicationErrorDao> jdbi3DaoExtension =

--- a/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/MySqlJdbcApplicationErrorDaoTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/dao/jdk/MySqlJdbcApplicationErrorDaoTest.java
@@ -1,7 +1,7 @@
 package org.kiwiproject.dropwizard.error.dao.jdk;
 
 import static org.kiwiproject.dropwizard.error.util.TestHelpers.migrateDatabase;
-import static org.kiwiproject.dropwizard.error.util.TestHelpers.newLatestMySQLContainer;
+import static org.kiwiproject.dropwizard.error.util.TestHelpers.newLtsMySQLContainer;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -17,7 +17,7 @@ class MySqlJdbcApplicationErrorDaoTest extends AbstractJdbcApplicationErrorDaoTe
     private static SimpleSingleConnectionDataSource dataSource;
 
     @Container
-    private static final MySQLContainer<?> MYSQL = newLatestMySQLContainer();
+    private static final MySQLContainer<?> MYSQL = newLtsMySQLContainer();
 
     @BeforeAll
     static void beforeAll() {

--- a/src/test/java/org/kiwiproject/dropwizard/error/util/TestHelpers.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/util/TestHelpers.java
@@ -12,11 +12,10 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-
-import javax.sql.DataSource;
 
 @UtilityClass
 @Slf4j
@@ -41,8 +40,8 @@ public class TestHelpers {
                 "Connection is not to an H2 database. Database product name: %s", databaseProductName);
     }
 
-    public static MySQLContainer<?> newLatestMySQLContainer() {
-        return new MySQLContainer<>(DockerImageName.parse("mysql:latest"));
+    public static MySQLContainer<?> newLtsMySQLContainer() {
+        return new MySQLContainer<>(DockerImageName.parse("mysql:lts"));
     }
 
     /**


### PR DESCRIPTION
MySQL tests are now failing when using mysql:latest (where 'latest' is 9.3.0-1.el9)

See "[Bug]: mysql container Unable to start"
at https://github.com/testcontainers/testcontainers-java/issues/10184

Switch to mysql:lts so that:
(a) it works again
(b) it is hopefully more stable