### PR TITLE
feat(test): add ApplicationErrorAssert fluent assertion utility

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/error/test/assertj/ApplicationErrorAssert.java
+++ b/src/main/java/org/kiwiproject/dropwizard/error/test/assertj/ApplicationErrorAssert.java
@@ -1,0 +1,370 @@
+package org.kiwiproject.dropwizard.error.test.assertj;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.kiwiproject.dropwizard.error.model.ApplicationError;
+
+import static java.util.Objects.nonNull;
+
+import java.util.Objects;
+
+/**
+ * AssertJ-style fluent assertions for {@link ApplicationError}, intended for use in tests.
+ * <p>
+ * Use {@link #assertThatApplicationError(ApplicationError)} as the entry point.
+ * All methods return {@code this} to support fluent assertion chaining.
+ * Note that assertions stop at the first failure, unlike JUnit's {@code assertAll}.
+ * <p>
+ * For Mockito-based verification of {@link org.kiwiproject.dropwizard.error.dao.ApplicationErrorDao}
+ * interactions, see {@link org.kiwiproject.dropwizard.error.test.mockito.ApplicationErrorVerifications}
+ * and {@link org.kiwiproject.dropwizard.error.test.mockito.ApplicationErrorMatchers}.
+ */
+@SuppressWarnings("UnusedReturnValue")
+public class ApplicationErrorAssert extends AbstractAssert<ApplicationErrorAssert, ApplicationError> {
+
+    ApplicationErrorAssert(ApplicationError actual) {
+        super(actual, ApplicationErrorAssert.class);
+    }
+
+    /**
+     * Starting point for fluent assertions on an {@link ApplicationError}.
+     *
+     * @param actual the ApplicationError to assert upon
+     * @return a new {@link ApplicationErrorAssert} instance
+     */
+    public static ApplicationErrorAssert assertThatApplicationError(ApplicationError actual) {
+        return new ApplicationErrorAssert(actual);
+    }
+
+    /**
+     * Asserts the error has the given description.
+     *
+     * @param description the expected description
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasDescription(String description) {
+        isNotNull();
+        if (!Objects.equals(actual.getDescription(), description)) {
+            failWithMessage("Expected description <%s> but was <%s>", description, actual.getDescription());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error description contains the given fragment.
+     *
+     * @param fragment the expected fragment
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasDescriptionContaining(String fragment) {
+        isNotNull();
+        Assertions.assertThat(actual.getDescription()).contains(fragment);
+        return this;
+    }
+
+    /**
+     * Asserts the error has an exception type matching the given class's fully-qualified name.
+     *
+     * @param type the expected exception type; must not be null
+     * @return this instance
+     * @implNote Compares against {@link Class#getName()}, not {@code getSimpleName()} or
+     * {@code getCanonicalName()}, which matters for inner classes and arrays.
+     */
+    public ApplicationErrorAssert hasExceptionType(Class<?> type) {
+        Objects.requireNonNull(type, "type must not be null");
+        return hasExceptionType(type.getName());
+    }
+
+    /**
+     * Asserts the error has the given fully-qualified exception type name.
+     *
+     * @param fqcn the expected fully-qualified class name
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasExceptionType(String fqcn) {
+        isNotNull();
+        if (!Objects.equals(actual.getExceptionType(), fqcn)) {
+            failWithMessage("Expected exceptionType <%s> but was <%s>", fqcn, actual.getExceptionType());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error has a null exception type.
+     *
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasNoExceptionType() {
+        isNotNull();
+        if (nonNull(actual.getExceptionType())) {
+            failWithMessage("Expected exceptionType to be null but was <%s>", actual.getExceptionType());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error has the given exception message.
+     *
+     * @param message the expected exception message
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasExceptionMessage(String message) {
+        isNotNull();
+        if (!Objects.equals(actual.getExceptionMessage(), message)) {
+            failWithMessage("Expected exceptionMessage <%s> but was <%s>", message, actual.getExceptionMessage());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error exception message contains the given fragment.
+     *
+     * @param fragment the expected fragment
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasExceptionMessageContaining(String fragment) {
+        isNotNull();
+        Assertions.assertThat(actual.getExceptionMessage()).contains(fragment);
+        return this;
+    }
+
+    /**
+     * Asserts the error has a null exception message.
+     *
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasNoExceptionMessage() {
+        isNotNull();
+        if (nonNull(actual.getExceptionMessage())) {
+            failWithMessage("Expected exceptionMessage to be null but was <%s>", actual.getExceptionMessage());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error has an exception cause type matching the given class's fully-qualified name.
+     *
+     * @param type the expected exception cause type; must not be null
+     * @return this instance
+     * @implNote Compares against {@link Class#getName()}, not {@code getSimpleName()} or
+     * {@code getCanonicalName()}, which matters for inner classes and arrays.
+     */
+    public ApplicationErrorAssert hasExceptionCauseType(Class<?> type) {
+        Objects.requireNonNull(type, "type must not be null");
+        return hasExceptionCauseType(type.getName());
+    }
+
+    /**
+     * Asserts the error has the given fully-qualified exception cause type name.
+     *
+     * @param fqcn the expected fully-qualified class name
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasExceptionCauseType(String fqcn) {
+        isNotNull();
+        if (!Objects.equals(actual.getExceptionCauseType(), fqcn)) {
+            failWithMessage("Expected exceptionCauseType <%s> but was <%s>", fqcn, actual.getExceptionCauseType());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error has a null exception cause type.
+     *
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasNoExceptionCauseType() {
+        isNotNull();
+        if (nonNull(actual.getExceptionCauseType())) {
+            failWithMessage("Expected exceptionCauseType to be null but was <%s>", actual.getExceptionCauseType());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error has the given exception cause message.
+     *
+     * @param message the expected exception cause message
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasExceptionCauseMessage(String message) {
+        isNotNull();
+        if (!Objects.equals(actual.getExceptionCauseMessage(), message)) {
+            failWithMessage("Expected exceptionCauseMessage <%s> but was <%s>", message, actual.getExceptionCauseMessage());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error exception cause message contains the given fragment.
+     *
+     * @param fragment the expected fragment
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasExceptionCauseMessageContaining(String fragment) {
+        isNotNull();
+        Assertions.assertThat(actual.getExceptionCauseMessage()).contains(fragment);
+        return this;
+    }
+
+    /**
+     * Asserts the error has a null exception cause message.
+     *
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasNoExceptionCauseMessage() {
+        isNotNull();
+        if (nonNull(actual.getExceptionCauseMessage())) {
+            failWithMessage("Expected exceptionCauseMessage to be null but was <%s>", actual.getExceptionCauseMessage());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error has the given stack trace.
+     *
+     * @param stackTrace the expected stack trace
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasStackTrace(String stackTrace) {
+        isNotNull();
+        if (!Objects.equals(actual.getStackTrace(), stackTrace)) {
+            failWithMessage("Expected stackTrace <%s> but was <%s>", stackTrace, actual.getStackTrace());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error stack trace contains the given fragment.
+     *
+     * @param fragment the expected fragment
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasStackTraceContaining(String fragment) {
+        isNotNull();
+        Assertions.assertThat(actual.getStackTrace()).contains(fragment);
+        return this;
+    }
+
+    /**
+     * Asserts the error has a null stack trace.
+     *
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasNoStackTrace() {
+        isNotNull();
+        if (nonNull(actual.getStackTrace())) {
+            failWithMessage("Expected stackTrace to be null but was <%s>", actual.getStackTrace());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error has occurred the given number of times.
+     *
+     * @param expected the expected number of occurrences
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasNumTimesOccurred(int expected) {
+        isNotNull();
+        if (actual.getNumTimesOccurred() != expected) {
+            failWithMessage("Expected numTimesOccurred <%d> but was <%d>", expected, actual.getNumTimesOccurred());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error is resolved.
+     *
+     * @return this instance
+     */
+    public ApplicationErrorAssert isResolved() {
+        isNotNull();
+        if (!actual.isResolved()) {
+            failWithMessage("Expected ApplicationError to be resolved but it was not");
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error is not resolved.
+     *
+     * @return this instance
+     */
+    public ApplicationErrorAssert isNotResolved() {
+        isNotNull();
+        if (actual.isResolved()) {
+            failWithMessage("Expected ApplicationError to not be resolved but it was");
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error has the given host name.
+     *
+     * @param hostName the expected host name
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasHostName(String hostName) {
+        isNotNull();
+        if (!Objects.equals(actual.getHostName(), hostName)) {
+            failWithMessage("Expected hostName <%s> but was <%s>", hostName, actual.getHostName());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error has the given IP address.
+     *
+     * @param ipAddress the expected IP address
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasIpAddress(String ipAddress) {
+        isNotNull();
+        if (!Objects.equals(actual.getIpAddress(), ipAddress)) {
+            failWithMessage("Expected ipAddress <%s> but was <%s>", ipAddress, actual.getIpAddress());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error has the given port.
+     *
+     * @param port the expected port
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasPort(int port) {
+        isNotNull();
+        if (actual.getPort() != port) {
+            failWithMessage("Expected port <%d> but was <%d>", port, actual.getPort());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error has the given id.
+     *
+     * @param id the expected id
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasId(long id) {
+        isNotNull();
+        if (!Objects.equals(actual.getId(), id)) {
+            failWithMessage("Expected id <%d> but was <%d>", id, actual.getId());
+        }
+        return this;
+    }
+
+    /**
+     * Asserts the error has a null id.
+     *
+     * @return this instance
+     */
+    public ApplicationErrorAssert hasNoId() {
+        isNotNull();
+        if (nonNull(actual.getId())) {
+            failWithMessage("Expected id to be null but was <%d>", actual.getId());
+        }
+        return this;
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/error/test/assertj/ApplicationErrorAssertTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/error/test/assertj/ApplicationErrorAssertTest.java
@@ -1,0 +1,613 @@
+package org.kiwiproject.dropwizard.error.test.assertj;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.kiwiproject.dropwizard.error.test.assertj.ApplicationErrorAssert.assertThatApplicationError;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwiproject.dropwizard.error.model.ApplicationError;
+import org.kiwiproject.dropwizard.error.model.ApplicationError.Resolved;
+import org.kiwiproject.dropwizard.error.model.PersistentHostInformation;
+import org.kiwiproject.dropwizard.error.test.junit.jupiter.ApplicationErrorExtension;
+import org.kiwiproject.dropwizard.error.test.junit.jupiter.ApplicationErrorExtension.HostInfo;
+
+import java.io.IOException;
+
+@DisplayName("ApplicationErrorAssert")
+@ExtendWith(ApplicationErrorExtension.class)
+// assertThatApplicationError is a trivial factory (no-throw), so S5778 does not apply
+@SuppressWarnings("java:S5778")
+class ApplicationErrorAssertTest {
+
+    private String hostName;
+    private String ipAddress;
+    private int port;
+
+    @BeforeEach
+    void setUp(@HostInfo PersistentHostInformation hostInfo) {
+        this.hostName = hostInfo.getHostName();
+        this.ipAddress = hostInfo.getIpAddress();
+        this.port = hostInfo.getPort();
+    }
+
+    @Nested
+    class AssertThatApplicationErrorFactory {
+
+        @Test
+        void shouldReturnAssertInstance() {
+            var error = ApplicationError.newUnresolvedError("test");
+            assertThat(assertThatApplicationError(error)).isInstanceOf(ApplicationErrorAssert.class);
+        }
+
+        @Test
+        void shouldFailWhenActualIsNull() {
+            assertThatThrownBy(() -> assertThatApplicationError(null).hasDescription("anything"))
+                    .isInstanceOf(AssertionError.class);
+        }
+    }
+
+    @Nested
+    class HasDescription {
+
+        @Test
+        void shouldPass_WhenDescriptionMatches() {
+            var error = ApplicationError.newUnresolvedError("expected description");
+
+            assertThatCode(() -> assertThatApplicationError(error).hasDescription("expected description"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenDescriptionDoesNotMatch() {
+            var error = ApplicationError.newUnresolvedError("actual description");
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasDescription("wrong description"))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("wrong description")
+                    .hasMessageContaining("actual description");
+        }
+    }
+
+    @Nested
+    class HasDescriptionContaining {
+
+        @Test
+        void shouldPass_WhenDescriptionContainsFragment() {
+            var error = ApplicationError.newUnresolvedError("an I/O error occurred: no such file");
+
+            assertThatCode(() -> assertThatApplicationError(error).hasDescriptionContaining("I/O error"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenDescriptionDoesNotContainFragment() {
+            var error = ApplicationError.newUnresolvedError("some error");
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasDescriptionContaining("missing fragment"))
+                    .isInstanceOf(AssertionError.class);
+        }
+    }
+
+    @Nested
+    class HasExceptionType {
+
+        @Test
+        void shouldPass_WhenExceptionTypeMatchesClass() {
+            var error = ApplicationError.newUnresolvedError("error with exception", new IOException("io problem"));
+
+            assertThatCode(() -> assertThatApplicationError(error).hasExceptionType(IOException.class))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldPass_WhenExceptionTypeMatchesFqcn() {
+            var error = ApplicationError.newUnresolvedError("error with exception", new IOException("io problem"));
+
+            assertThatCode(() -> assertThatApplicationError(error).hasExceptionType(IOException.class.getName()))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenExceptionTypeDoesNotMatch() {
+            var error = ApplicationError.newUnresolvedError("error with exception", new IOException("io problem"));
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasExceptionType(RuntimeException.class))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining(RuntimeException.class.getName())
+                    .hasMessageContaining(IOException.class.getName());
+        }
+
+        @Test
+        void shouldFail_WhenExceptionTypeFqcnDoesNotMatch() {
+            var error = ApplicationError.newUnresolvedError("error with exception", new IOException("io problem"));
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasExceptionType(RuntimeException.class.getName()))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining(RuntimeException.class.getName())
+                    .hasMessageContaining(IOException.class.getName());
+        }
+    }
+
+    @Nested
+    class HasNoExceptionType {
+
+        @Test
+        void shouldPass_WhenExceptionTypeIsNull() {
+            var error = ApplicationError.newUnresolvedError("error without exception");
+
+            assertThatCode(() -> assertThatApplicationError(error).hasNoExceptionType())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenExceptionTypeIsNotNull() {
+            var error = ApplicationError.newUnresolvedError("error with exception", new IOException("io problem"));
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasNoExceptionType())
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining(IOException.class.getName());
+        }
+    }
+
+    @Nested
+    class HasExceptionMessage {
+
+        @Test
+        void shouldPass_WhenExceptionMessageMatches() {
+            var error = ApplicationError.newUnresolvedError("some error", new IOException("io problem"));
+
+            assertThatCode(() -> assertThatApplicationError(error).hasExceptionMessage("io problem"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenExceptionMessageDoesNotMatch() {
+            var error = ApplicationError.newUnresolvedError("some error", new IOException("io problem"));
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasExceptionMessage("wrong message"))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("wrong message")
+                    .hasMessageContaining("io problem");
+        }
+    }
+
+    @Nested
+    class HasExceptionMessageContaining {
+
+        @Test
+        void shouldPass_WhenExceptionMessageContainsFragment() {
+            var error = ApplicationError.newUnresolvedError("some error", new IOException("connection reset by peer"));
+
+            assertThatCode(() -> assertThatApplicationError(error).hasExceptionMessageContaining("connection reset"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenExceptionMessageDoesNotContainFragment() {
+            var error = ApplicationError.newUnresolvedError("some error", new IOException("connection reset by peer"));
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasExceptionMessageContaining("missing fragment"))
+                    .isInstanceOf(AssertionError.class);
+        }
+    }
+
+    @Nested
+    class HasNoExceptionMessage {
+
+        @Test
+        void shouldPass_WhenExceptionMessageIsNull() {
+            var error = ApplicationError.newUnresolvedError("error without exception");
+
+            assertThatCode(() -> assertThatApplicationError(error).hasNoExceptionMessage())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenExceptionMessageIsNotNull() {
+            var error = ApplicationError.newUnresolvedError("some error", new IOException("io problem"));
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasNoExceptionMessage())
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("io problem");
+        }
+    }
+
+    @Nested
+    class HasExceptionCauseType {
+
+        @Test
+        void shouldPass_WhenExceptionCauseTypeMatchesClass() {
+            var cause = new IOException("original cause");
+            var error = ApplicationError.newUnresolvedError("some error", new RuntimeException("wrapper", cause));
+
+            assertThatCode(() -> assertThatApplicationError(error).hasExceptionCauseType(IOException.class))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldPass_WhenExceptionCauseTypeMatchesFqcn() {
+            var cause = new IOException("original cause");
+            var error = ApplicationError.newUnresolvedError("some error", new RuntimeException("wrapper", cause));
+
+            assertThatCode(() -> assertThatApplicationError(error).hasExceptionCauseType(IOException.class.getName()))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenExceptionCauseTypeDoesNotMatch() {
+            var cause = new IOException("original cause");
+            var error = ApplicationError.newUnresolvedError("some error", new RuntimeException("wrapper", cause));
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasExceptionCauseType(IllegalArgumentException.class))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining(IllegalArgumentException.class.getName())
+                    .hasMessageContaining(IOException.class.getName());
+        }
+
+        @Test
+        void shouldFail_WhenExceptionCauseTypeFqcnDoesNotMatch() {
+            var cause = new IOException("original cause");
+            var error = ApplicationError.newUnresolvedError("some error", new RuntimeException("wrapper", cause));
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasExceptionCauseType(IllegalArgumentException.class.getName()))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining(IllegalArgumentException.class.getName())
+                    .hasMessageContaining(IOException.class.getName());
+        }
+    }
+
+    @Nested
+    class HasNoExceptionCauseType {
+
+        @Test
+        void shouldPass_WhenExceptionCauseTypeIsNull() {
+            var error = ApplicationError.newUnresolvedError("error without exception");
+
+            assertThatCode(() -> assertThatApplicationError(error).hasNoExceptionCauseType())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenExceptionCauseTypeIsNotNull() {
+            var cause = new IOException("original cause");
+            var error = ApplicationError.newUnresolvedError("some error", new RuntimeException("wrapper", cause));
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasNoExceptionCauseType())
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining(IOException.class.getName());
+        }
+    }
+
+    @Nested
+    class HasExceptionCauseMessage {
+
+        @Test
+        void shouldPass_WhenExceptionCauseMessageMatches() {
+            var cause = new IOException("original cause message");
+            var error = ApplicationError.newUnresolvedError("some error", new RuntimeException("wrapper", cause));
+
+            assertThatCode(() -> assertThatApplicationError(error).hasExceptionCauseMessage("original cause message"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenExceptionCauseMessageDoesNotMatch() {
+            var cause = new IOException("original cause message");
+            var error = ApplicationError.newUnresolvedError("some error", new RuntimeException("wrapper", cause));
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasExceptionCauseMessage("wrong message"))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("wrong message")
+                    .hasMessageContaining("original cause message");
+        }
+    }
+
+    @Nested
+    class HasExceptionCauseMessageContaining {
+
+        @Test
+        void shouldPass_WhenExceptionCauseMessageContainsFragment() {
+            var cause = new IOException("file /data/foo.txt not found");
+            var error = ApplicationError.newUnresolvedError("some error", new RuntimeException("wrapper", cause));
+
+            assertThatCode(() -> assertThatApplicationError(error).hasExceptionCauseMessageContaining("/data/foo.txt"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenExceptionCauseMessageDoesNotContainFragment() {
+            var cause = new IOException("file /data/foo.txt not found");
+            var error = ApplicationError.newUnresolvedError("some error", new RuntimeException("wrapper", cause));
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasExceptionCauseMessageContaining("missing fragment"))
+                    .isInstanceOf(AssertionError.class);
+        }
+    }
+
+    @Nested
+    class HasNoExceptionCauseMessage {
+
+        @Test
+        void shouldPass_WhenExceptionCauseMessageIsNull() {
+            var error = ApplicationError.newUnresolvedError("error without exception");
+
+            assertThatCode(() -> assertThatApplicationError(error).hasNoExceptionCauseMessage())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenExceptionCauseMessageIsNotNull() {
+            var cause = new IOException("original cause message");
+            var error = ApplicationError.newUnresolvedError("some error", new RuntimeException("wrapper", cause));
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasNoExceptionCauseMessage())
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("original cause message");
+        }
+    }
+
+    @Nested
+    class HasStackTrace {
+
+        @Test
+        void shouldPass_WhenStackTraceMatches() {
+            var exception = new IOException("io error");
+            var error = ApplicationError.newUnresolvedError("some error", exception);
+            var expectedStackTrace = error.getStackTrace();
+
+            assertThatCode(() -> assertThatApplicationError(error).hasStackTrace(expectedStackTrace))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenStackTraceDoesNotMatch() {
+            var error = ApplicationError.newUnresolvedError("some error", new IOException("io error"));
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasStackTrace("wrong stack trace"))
+                    .isInstanceOf(AssertionError.class);
+        }
+    }
+
+    @Nested
+    class HasStackTraceContaining {
+
+        @Test
+        void shouldPass_WhenStackTraceContainsFragment() {
+            var error = ApplicationError.newUnresolvedError("some error", new IOException("io error"));
+
+            assertThatCode(() ->
+                    assertThatApplicationError(error).hasStackTraceContaining("java.io.IOException"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenStackTraceDoesNotContainFragment() {
+            var error = ApplicationError.newUnresolvedError("some error", new IOException("io error"));
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasStackTraceContaining("someNonExistentMethod"))
+                    .isInstanceOf(AssertionError.class);
+        }
+    }
+
+    @Nested
+    class HasNoStackTrace {
+
+        @Test
+        void shouldPass_WhenStackTraceIsNull() {
+            var error = ApplicationError.newUnresolvedError("error without exception");
+
+            assertThatCode(() -> assertThatApplicationError(error).hasNoStackTrace())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenStackTraceIsNotNull() {
+            var error = ApplicationError.newUnresolvedError("some error", new IOException("io error"));
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasNoStackTrace())
+                    .isInstanceOf(AssertionError.class);
+        }
+    }
+
+    @Nested
+    class HasNumTimesOccurred {
+
+        @Test
+        void shouldPass_WhenCountMatches() {
+            var error = ApplicationError.newUnresolvedError("some error");
+
+            assertThatCode(() -> assertThatApplicationError(error).hasNumTimesOccurred(1))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenCountDoesNotMatch() {
+            var error = ApplicationError.newUnresolvedError("some error");
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasNumTimesOccurred(5))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("5")
+                    .hasMessageContaining("1");
+        }
+    }
+
+    @Nested
+    class IsResolved {
+
+        @Test
+        void shouldPass_WhenErrorIsResolved() {
+            var error = ApplicationError.newError("some error", Resolved.YES, hostName, ipAddress, port, null);
+
+            assertThatCode(() -> assertThatApplicationError(error).isResolved())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenErrorIsNotResolved() {
+            var error = ApplicationError.newUnresolvedError("some error");
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).isResolved())
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("resolved");
+        }
+    }
+
+    @Nested
+    class IsNotResolved {
+
+        @Test
+        void shouldPass_WhenErrorIsNotResolved() {
+            var error = ApplicationError.newUnresolvedError("some error");
+
+            assertThatCode(() -> assertThatApplicationError(error).isNotResolved())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenErrorIsResolved() {
+            var error = ApplicationError.newError("some error", Resolved.YES, hostName, ipAddress, port, null);
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).isNotResolved())
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("resolved");
+        }
+    }
+
+    @Nested
+    class HasHostName {
+
+        @Test
+        void shouldPass_WhenHostNameMatches() {
+            var error = ApplicationError.newUnresolvedError("some error");
+
+            assertThatCode(() -> assertThatApplicationError(error).hasHostName(hostName))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenHostNameDoesNotMatch() {
+            var error = ApplicationError.newUnresolvedError("some error");
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasHostName("wrong-host"))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("wrong-host")
+                    .hasMessageContaining(hostName);
+        }
+    }
+
+    @Nested
+    class HasIpAddress {
+
+        @Test
+        void shouldPass_WhenIpAddressMatches() {
+            var error = ApplicationError.newUnresolvedError("some error");
+
+            assertThatCode(() -> assertThatApplicationError(error).hasIpAddress(ipAddress))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenIpAddressDoesNotMatch() {
+            var error = ApplicationError.newUnresolvedError("some error");
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasIpAddress("1.2.3.4"))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("1.2.3.4")
+                    .hasMessageContaining(ipAddress);
+        }
+    }
+
+    @Nested
+    class HasPort {
+
+        @Test
+        void shouldPass_WhenPortMatches() {
+            var error = ApplicationError.newUnresolvedError("some error");
+
+            assertThatCode(() -> assertThatApplicationError(error).hasPort(port))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenPortDoesNotMatch() {
+            var error = ApplicationError.newUnresolvedError("some error");
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasPort(9999))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("9999")
+                    .hasMessageContaining(String.valueOf(port));
+        }
+    }
+
+    @Nested
+    class HasId {
+
+        @Test
+        void shouldPass_WhenIdMatches() {
+            var error = ApplicationError.newUnresolvedError("some error").withId(42L);
+
+            assertThatCode(() -> assertThatApplicationError(error).hasId(42L))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenIdDoesNotMatch() {
+            var error = ApplicationError.newUnresolvedError("some error").withId(42L);
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasId(99L))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("99")
+                    .hasMessageContaining("42");
+        }
+    }
+
+    @Nested
+    class HasNoId {
+
+        @Test
+        void shouldPass_WhenIdIsNull() {
+            var error = ApplicationError.newUnresolvedError("some error");
+
+            assertThatCode(() -> assertThatApplicationError(error).hasNoId())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenIdIsNotNull() {
+            var error = ApplicationError.newUnresolvedError("some error").withId(42L);
+
+            assertThatThrownBy(() -> assertThatApplicationError(error).hasNoId())
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("42");
+        }
+    }
+
+    @Nested
+    class FluentChaining {
+
+        @Test
+        void shouldSupportChainingMultipleAssertions() {
+            var cause = new IOException("file not found");
+            var error = ApplicationError.newUnresolvedError("an I/O error occurred", new RuntimeException("wrapper", cause));
+
+            assertThatApplicationError(error)
+                    .hasDescription("an I/O error occurred")
+                    .hasExceptionType(RuntimeException.class)
+                    .hasExceptionMessage("wrapper")
+                    .hasExceptionCauseType(IOException.class)
+                    .hasExceptionCauseMessage("file not found")
+                    .hasStackTraceContaining("java.io.IOException")
+                    .hasNumTimesOccurred(1)
+                    .isNotResolved()
+                    .hasHostName(hostName)
+                    .hasIpAddress(ipAddress)
+                    .hasPort(port)
+                    .hasNoId();
+        }
+    }
+}


### PR DESCRIPTION
Add AssertJ-style fluent assertions for ApplicationError by
introducing ApplicationErrorAssert, which extends AssertJ's
AbstractAssert. The entry point is assertThatApplicationError.

Supports chaining assertions on all ApplicationError fields:
description, exception type/message, cause type/message,
stack trace, numTimesOccurred, resolved status, host info, and id.
Each field has both equality and (where applicable) contains
variants, as well as a hasNoX variant for null checks.

Closes #499